### PR TITLE
Remove os prefix from consecutive build error.

### DIFF
--- a/superflore/generators/bitbake/run.py
+++ b/superflore/generators/bitbake/run.py
@@ -14,6 +14,7 @@
 
 from superflore.generators.bitbake.gen_packages import generate_installers
 from superflore.generators.bitbake.ros_meta import ros_meta
+from superflore import RepoInstance
 import argparse
 import shutil
 import sys
@@ -85,18 +86,15 @@ def main():
 
     # clone current repo
     selected_targets = active_distros
-    try:
-        link_existing_files(args.ros_distro)
-    except FileExistsError:
-        warn_msg = 'Detected existing rosdistro ebuild structure... '
-        warn_msg += 'Removing and overwriting.'
-        ros_meta.warn(warn_msg)
-        for x in active_distros:
-            try:
-                os.remove('recipes-ros-{0}'.format(x))
-            except:
-                pass
-        link_existing_files(args.ros_distro)
+    for x in active_distros:
+        try:
+            os.remove('recipes-ros-{0}'.format(x))
+            warn_msg =\
+                'removing existing symlink "./recipes-ros-{0}"'.format(x)
+            RepoInstance.warn(warn_msg)
+        except:
+            pass
+    link_existing_files(args.ros_distro)
 
     # generate installers
     total_installers = dict()

--- a/superflore/generators/bitbake/run.py
+++ b/superflore/generators/bitbake/run.py
@@ -85,9 +85,8 @@ def main():
 
     # clone current repo
     selected_targets = active_distros
-    # try:
-    link_existing_files(args.ros_distro)
-    """
+    try:
+        link_existing_files(args.ros_distro)
     except FileExistsError:
         warn_msg = 'Detected existing rosdistro ebuild structure... '
         warn_msg += 'Removing and overwriting.'
@@ -97,8 +96,8 @@ def main():
                 os.remove('recipes-ros-{0}'.format(x))
             except:
                 pass
-        link_existing_files()
-    """
+        link_existing_files(args.ros_distro)
+
     # generate installers
     total_installers = dict()
     total_broken = set()

--- a/superflore/generators/ebuild/gen_packages.py
+++ b/superflore/generators/ebuild/gen_packages.py
@@ -68,7 +68,6 @@ def get_pkg_version(distro, pkg_name):
 
 
 def generate_installers(distro_name, overlay, preserve_existing=True):
-    make_dir("ros-{}".format(distro_name))
     distro = get_distro(distro_name)
     pkg_names = get_package_names(distro)
     total = float(len(pkg_names[0]))

--- a/superflore/generators/ebuild/overlay_instance.py
+++ b/superflore/generators/ebuild/overlay_instance.py
@@ -20,13 +20,16 @@ def get_random_branch_name():
 class RosOverlay(object):
     def __init__(self, repo_dir=None):
         # clone repo into a random tmp directory.
+        do_clone = True
+        if repo_dir:
+            do_clone = not os.path.exists(os.path.realpath(repo_dir))
         self.repo = RepoInstance(
             'ros', 'ros-overlay',
             repo_dir or get_random_tmp_dir(),
-            not os.path.exists(os.path.realpath(repo_dir))
+            do_clone
         )
         self.branch_name = get_random_branch_name()
-        if not os.path.exists(os.path.realpath(repo_dir)):
+        if do_clone:
             self.repo.clone()
         branch_msg = 'Creating new branch {0}...'.format(self.branch_name)
         self.repo.info(branch_msg)

--- a/superflore/generators/ebuild/overlay_instance.py
+++ b/superflore/generators/ebuild/overlay_instance.py
@@ -18,11 +18,16 @@ def get_random_branch_name():
 
 
 class RosOverlay(object):
-    def __init__(self):
+    def __init__(self, repo_dir=None):
         # clone repo into a random tmp directory.
-        self.repo = RepoInstance('ros', 'ros-overlay', get_random_tmp_dir())
+        self.repo = RepoInstance(
+            'ros', 'ros-overlay',
+            repo_dir or get_random_tmp_dir(),
+            not os.path.exists(os.path.realpath(repo_dir))
+        )
         self.branch_name = get_random_branch_name()
-        self.repo.clone()
+        if not os.path.exists(os.path.realpath(repo_dir)):
+            self.repo.clone()
         branch_msg = 'Creating new branch {0}...'.format(self.branch_name)
         self.repo.info(branch_msg)
         self.repo.create_branch(self.branch_name)

--- a/superflore/generators/ebuild/run.py
+++ b/superflore/generators/ebuild/run.py
@@ -30,39 +30,6 @@ preserve_existing = True
 overlay = None
 
 
-def link_existing_files(mode):
-    global overlay
-    sym_link_msg = 'Symbolicly linking files from {0}/ros-{1}...'
-    dir_fmt = '{0}/ros-{1}'
-    if not mode:
-        for x in active_distros:
-            RepoInstance.info(sym_link_msg.format(overlay.repo.repo_dir, x))
-            os.symlink(dir_fmt.format(overlay.repo.repo_dir, x), './ros-' + x)
-    else:
-        # only link the relevant directory.
-        RepoInstance.info(sym_link_msg.format(overlay.repo_dir, mode))
-        os.symlink(
-            dir_fmt.format(overlay.repo.repo_dir, mode),
-            './ros-' + mode
-        )
-
-
-def get_existing_repo():
-    existing_path = None
-    for x in active_distros:
-        curr = './ros-{0}'.format(x)
-        if os.path.exists(curr):
-            existing_path = curr
-            break
-    if not existing_path:
-        raise RuntimeError('No existing repo found')
-    # get the actual location of the repo
-    repo_dir = os.path.realpath('{0}/../'.format(existing_path))
-    # TODO(allenh1): make this configurable
-    git_repo = RepoInstance('ros', 'ros-overlay', repo_dir, do_clone=False)
-    return git_repo
-
-
 def clean_up(distro, preserve_repo=False):
     global overlay
     if not preserve_repo:
@@ -70,12 +37,6 @@ def clean_up(distro, preserve_repo=False):
             'Cleaning up tmp directory {0}...'.format(overlay.repo.repo_dir)
         RepoInstance.info(clean_msg)
         shutil.rmtree(overlay.repo.repo_dir)
-    RepoInstance.info('Cleaning up symbolic links...')
-    if distro in active_distros:
-        os.remove('ros-{0}'.format(distro))
-    else:
-        for x in active_distros:
-            os.remove('ros-{0}'.format(x))
     if os.path.exists('.pr-message.tmp'):
         os.remove('.pr-message.tmp')
     if os.path.exists('.pr-title.tmp'):
@@ -133,6 +94,8 @@ def main():
     elif args.dry_run and args.pr_only:
         RepoInstance.error('Invalid args! cannot dry-run and file PR')
         sys.exit(1)
+    elif args.pr_only and not args.output_repository_path:
+        RepoInstance.error('Invalid args! no repository specified') 
     elif args.pr_only:
         try:
             with open('.pr-message.tmp', 'r') as msg_file:
@@ -149,7 +112,7 @@ def main():
             )
             sys.exit(1)
         try:
-            prev_overlay = get_existing_repo()
+            prev_overlay = RepoInstance(args.output_repository_path)
             RepoInstance.info('PR message:\n"%s"\n' % msg)
             RepoInstance.info('PR title:\n"%s"\n' % title)
             prev_overlay.pull_request(msg, title)
@@ -162,15 +125,6 @@ def main():
     # clone current repo
     overlay = RosOverlay(args.output_repository_path)
     selected_targets = active_distros
-
-    for x in active_distros:
-        try:
-            os.remove('ros-{0}'.format(x))
-            warn_msg = 'removing existing symlink "./ros-{0}"'.format(x)
-            RepoInstance.warn(warn_msg)
-        except:
-            pass
-    link_existing_files(args.ros_distro)
     # generate installers
     total_installers = dict()
     total_broken = set()

--- a/superflore/generators/ebuild/run.py
+++ b/superflore/generators/ebuild/run.py
@@ -159,7 +159,7 @@ def main():
 
     try:
         link_existing_files(args.ros_distro)
-    except os.FileExistsError:
+    except FileExistsError:
         warn_msg = 'Detected existing rosdistro ebuild structure... '
         warn_msg += 'Removing and overwriting.'
         RepoInstance.warn(warn_msg)

--- a/superflore/generators/ebuild/run.py
+++ b/superflore/generators/ebuild/run.py
@@ -23,9 +23,6 @@ import time
 import sys
 import os
 
-if sys.version_info < (3, 0):
-    from os.FileExistsError import FileExistsError
-
 # Modify if a new distro is added
 active_distros = ['indigo', 'kinetic', 'lunar']
 # just update packages, by default.
@@ -166,19 +163,14 @@ def main():
     overlay = RosOverlay(args.output_repository_path)
     selected_targets = active_distros
 
-    try:
-        link_existing_files(args.ros_distro)
-    except FileExistsError:
-        warn_msg = 'Detected existing rosdistro ebuild structure... '
-        warn_msg += 'Removing and overwriting.'
-        RepoInstance.warn(warn_msg)
-        for x in active_distros:
-            try:
-                os.remove('ros-{0}'.format(x))
-            except:
-                pass
-
-        link_existing_files(args.ros_distro)
+    for x in active_distros:
+        try:
+            os.remove('ros-{0}'.format(x))
+            warn_msg = 'removing existing symlink "./ros-{0}"'.format(x)
+            RepoInstance.warn(warn_msg)
+        except:
+            pass
+    link_existing_files(args.ros_distro)
     # generate installers
     total_installers = dict()
     total_broken = set()

--- a/superflore/generators/ebuild/run.py
+++ b/superflore/generators/ebuild/run.py
@@ -95,7 +95,7 @@ def main():
         RepoInstance.error('Invalid args! cannot dry-run and file PR')
         sys.exit(1)
     elif args.pr_only and not args.output_repository_path:
-        RepoInstance.error('Invalid args! no repository specified') 
+        RepoInstance.error('Invalid args! no repository specified')
     elif args.pr_only:
         try:
             with open('.pr-message.tmp', 'r') as msg_file:

--- a/superflore/repo_instance.py
+++ b/superflore/repo_instance.py
@@ -24,10 +24,7 @@ class RepoInstance(object):
         self.repo_name = repo_name
         repo_url = 'https://github.com/{0}/{1}'
         self.repo_url = repo_url.format(self.repo_owner, self.repo_name)
-        if repo_dir is not None:
-            self.repo_dir = repo_dir
-        else:
-            self.repo_dir = self.repo_name
+        self.repo_dir = repo_dir or self.repo_name
         if do_clone:
             self.repo = Repo.clone_from(self.repo_url, self.repo_dir)
         else:


### PR DESCRIPTION
Fixes traceback for #50 

Current behavior just removes the symlinks. I should adapt this to remove the existing tmp directory as well.

connects to #50 
connects to #32 