### PR TITLE
Adds a way to remove Python3 support from packages

### DIFF
--- a/superflore/generators/ebuild/ebuild.py
+++ b/superflore/generators/ebuild/ebuild.py
@@ -58,6 +58,7 @@ class Ebuild(object):
         self.name = None
         self.has_patches = False
         self.die_msg = None
+        self.python_3 = True
         self.illegal_desc_chars = '()[]{}|^$\\#\t\n\r\v\f\'\"\`'
 
     def add_build_depend(self, depend, internal=True):
@@ -92,8 +93,10 @@ class Ebuild(object):
 
         # EAPI=<eapi>
         ret += "EAPI=" + self.eapi + "\n"
-        ret += "PYTHON_COMPAT=( python{2_7,3_5} )\n\n"
-
+        if self.python_3:
+            ret += "PYTHON_COMPAT=( python{2_7,3_5} )\n\n"
+        else:
+            ret += "PYTHON_COMPAT=( python2_7 )\n\n"
         # inherits
         ret += "inherit ros-cmake\n\n"
 

--- a/superflore/generators/ebuild/gen_packages.py
+++ b/superflore/generators/ebuild/gen_packages.py
@@ -31,7 +31,7 @@ org = "Open Source Robotics Foundation"
 org_license = "BSD"
 
 """
-This is a blacklist of things that
+TODO(allenh1): This is a blacklist of things that
 do not yet support Python 3. This will
 be updated on an as-needed basis until
 a better solution is found (CI?).

--- a/superflore/generators/ebuild/gen_packages.py
+++ b/superflore/generators/ebuild/gen_packages.py
@@ -30,12 +30,12 @@ from .metadata_xml import metadata_xml
 org = "Open Source Robotics Foundation"
 org_license = "BSD"
 
-"""
-TODO(allenh1): This is a blacklist of things that
-do not yet support Python 3. This will
-be updated on an as-needed basis until
-a better solution is found (CI?).
-"""
+
+# TODO(allenh1): This is a blacklist of things that
+# do not yet support Python 3. This will be updated
+# on an as-needed basis until a better solution is
+# found (CI?).
+
 no_python3 = [ 'tf' ]
 
 def warn(string):

--- a/superflore/generators/ebuild/gen_packages.py
+++ b/superflore/generators/ebuild/gen_packages.py
@@ -30,6 +30,13 @@ from .metadata_xml import metadata_xml
 org = "Open Source Robotics Foundation"
 org_license = "BSD"
 
+"""
+This is a blacklist of things that
+do not yet support Python 3. This will
+be updated on an as-needed basis until
+a better solution is found (CI?).
+"""
+no_python3 = [ 'tf' ]
 
 def warn(string):
     print(colored('>>>> {0}'.format(string), 'yellow'))
@@ -276,6 +283,9 @@ class gentoo_installer(object):
             _gen_ebuild_for_package(distro, pkg_name,
                                     pkg, repo, ros_pkg, pkg_rosinstall)
         self.ebuild.has_patches = has_patches
+
+        if pkg_name in no_python3:
+            self.ebuild.python_3 = False
 
     def metadata_text(self):
         return self.metadata_xml.get_metadata_text()


### PR DESCRIPTION
It's not great, but I can't think of a truly robust way to do this.