### PR TITLE
Always remove an existing manifest when creating new ebuilds.

### DIFF
--- a/superflore/generators/ebuild/gen_packages.py
+++ b/superflore/generators/ebuild/gen_packages.py
@@ -95,8 +95,10 @@ def generate_installers(distro_name, overlay, preserve_existing=True):
             continue
         # otherwise, remove a (potentially) existing ebuild.
         existing = glob.glob('ros-{0}/{1}/*.ebuild'.format(distro_name, pkg))
-        if len(existing) > 0:
+        if existing:
             overlay.remove_file(existing[0])
+            manifest_file = 'ros-{0}/{1}/Manifest'.format(distro_name, pkg)
+            overlay.remove_file(manifest_file)
         try:
             current = gentoo_installer(distro, pkg, has_patches)
             current.ebuild.name = pkg


### PR DESCRIPTION
I encountered some issues with Manifests that this should resolve. Some form of caching prevented the new tars from being downloaded.