### PR TITLE
Add a distro-specific name to the archive name.

### DIFF
--- a/superflore/generators/ebuild/ebuild.py
+++ b/superflore/generators/ebuild/ebuild.py
@@ -112,7 +112,8 @@ class Ebuild(object):
             ret += "DESCRIPTION=\"NONE\"\n"
 
         ret += "HOMEPAGE=\"" + self.homepage + "\"\n"
-        ret += "SRC_URI=\"" + self.src_uri + " -> ${PN}-release-${PV}.tar.gz\"\n\n"
+        ret += "SRC_URI=\"" + self.src_uri
+        ret += " -> ${PN}-" + self.distro + "-release-${PV}.tar.gz\"\n\n"
         try:
             # license -- only add if valid
             if isinstance(self.upstream_license, str):


### PR DESCRIPTION
This is along the lines of #55. This helps me from having to have to regenerate manifests all the time.