### PR TITLE
Initial rosdep support for gentoo.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,6 @@ python:
 install:
   - pip install nose flake8 termcolor git-pull-request
   - pip install xmltodict gitpython rosinstall_generator
-  - pip install rosdistro requests
+  - pip install rosdistro requests rosdep
 # command to run tests
 script: nosetests

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,7 @@ install_requires = [
     'setuptools',
     'rosinstall_generator',
     'rosdistro',
+    'rosdep',
     'gitpython',
     'git-pull-request',
     'requests'

--- a/superflore/generators/ebuild/ebuild.py
+++ b/superflore/generators/ebuild/ebuild.py
@@ -166,7 +166,8 @@ class Ebuild(object):
             ret += "    " + "ros-" + self.distro + "/" + rdep + "\n"
         for rdep in sorted(self.rdepends_external):
             try:
-                ret += "    " + resolve_dep(rdep, 'gentoo') + "\n"
+                for res in resolve_dep(rdep, 'gentoo')[0]: 
+                    ret += "    " + res + "\n"
             except UnresolvedDependency:
                 self.unresolved_deps.append(rdep)
 
@@ -178,7 +179,8 @@ class Ebuild(object):
             ret += "    " + 'ros-{0}/{1}\n'.format(self.distro, bdep)
         for bdep in sorted(self.depends_external):
             try:
-                ret += "    " + resolve_dep(bdep, 'gentoo') + "\n"
+                for res in resolve_dep(bdep, 'gentoo')[0]:
+                    ret += "    " + res + "\n"
             except UnresolvedDependency:
                 self.unresolved_deps.append(bdep)
         ret += "\"\n\n"

--- a/superflore/generators/ebuild/run.py
+++ b/superflore/generators/ebuild/run.py
@@ -101,7 +101,6 @@ def main():
                 pass
 
         link_existing_files(args.ros_distro)
-    download_yamls()
     # generate installers
     total_installers = dict()
     total_broken = set()

--- a/superflore/rosdep_support.py
+++ b/superflore/rosdep_support.py
@@ -1,0 +1,98 @@
+# Software License Agreement (BSD License)
+#
+# Copyright (c) 2013, Willow Garage, Inc.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#  * Neither the name of Willow Garage, Inc. nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+from rosdep2 import create_default_installer_context
+from rosdep2.catkin_support import get_catkin_view
+from rosdep2.lookup import ResolutionError
+
+from superflore.exceptions import UnresolvedDependency
+
+import rosdep2.catkin_support
+
+DEFAULT_ROS_DISTRO = 'indigo'
+view_cache = {}
+
+def get_view(os_name, os_version, ros_distro):
+    global view_cache
+    key = os_name + os_version + ros_distro
+    if key not in view_cache:
+        value = get_catkin_view(ros_distro, os_name, os_version, False)
+        view_cache[key] = value
+    return view_cache[key]
+
+
+def resolve_more_for_os(rosdep_key, view, installer, os_name, os_version):
+    """
+    Resolve rosdep key to dependencies and installer key.
+    (This was copied from rosdep2.catkin_support)
+
+    :param os_name: OS name, e.g. 'ubuntu'
+    :returns: resolved key, resolved installer key, and default installer key
+
+    :raises: :exc:`rosdep2.ResolutionError`
+    """
+    d = view.lookup(rosdep_key)
+    ctx = create_default_installer_context()
+    os_installers = ctx.get_os_installer_keys(os_name)
+    default_os_installer = ctx.get_default_os_installer_key(os_name)
+    inst_key, rule = d.get_rule_for_platform(os_name, os_version,
+                                             os_installers,
+                                             default_os_installer)
+    assert inst_key in os_installers
+    return installer.resolve(rule), inst_key, default_os_installer
+
+
+def resolve_rosdep_key(
+    key,
+    os_name,
+    os_version,
+    ros_distro=None,
+    ignored=None,
+    retry=True
+):
+    ignored = ignored or []
+    ctx = create_default_installer_context()
+    try:
+        installer_key = ctx.get_default_os_installer_key(os_name)
+    except KeyError:
+        BloomGenerator.exit("Could not determine the installer for '{0}'"
+                            .format(os_name))
+    installer = ctx.get_installer(installer_key)
+    ros_distro = ros_distro or DEFAULT_ROS_DISTRO
+    view = get_view(os_name, os_version, ros_distro)
+    try:
+        return resolve_more_for_os(key, view, installer, os_name, os_version)
+    except (KeyError, ResolutionError):
+        raise UnresolvedDependency(
+            "could not resolve package {} for os {}."
+            .format(key, os_name)
+        )

--- a/superflore/utils.py
+++ b/superflore/utils.py
@@ -16,7 +16,14 @@
 from superflore.exceptions import UnresolvedDependency
 from superflore.exceptions import UnknownPlatform
 from superflore.exceptions import UnknownLicense
+
+from rosdep2 import create_default_installer_context
+from rosdep2.catkin_support import get_catkin_view
+from rosdep2.lookup import ResolutionError
+
 from termcolor import colored
+
+import rosdep2.catkin_support
 import yaml
 import sys
 import re
@@ -33,6 +40,8 @@ else:
         response = urlopen(url)
         return response.read()
 
+DEFAULT_ROS_DISTRO = 'indigo'
+view_cache = {}
 
 def download_yamls():
     global base_yml
@@ -112,7 +121,7 @@ def resolve_dep(pkg, os):
     if os == 'oe':
         return _resolve_dep_open_embedded(pkg)
     elif os == 'gentoo':
-        return _resolve_dep_gentoo(pkg)
+        return resolve_rosdep_key(pkg, 'gentoo', '2.4.0')
     else:
         msg = "Unknown target platform '{0}'".format(os)
         raise UnknownPlatform(msg)
@@ -141,37 +150,56 @@ def _resolve_dep_open_embedded(pkg):
         return pkg.replace('_', '-')
 
 
-def _resolve_dep_gentoo(pkg):
-    global base_yml
-    global python_yml
-    global ruby_yml
-    if pkg not in base_yml:
-        if pkg not in python_yml:
-            if pkg not in ruby_yml:
-                raise UnresolvedDependency(
-                    "could not resolve package {} for Gentoo.".format(pkg))
-            elif 'gentoo'not in ruby_yml[pkg]:
-                raise UnresolvedDependency(
-                    "could not resolve package {} for Gentoo.".format(pkg))
-            elif 'portage' in ruby_yml[pkg]['gentoo']:
-                return ruby_yml[pkg]['gentoo']['portage']['packages'][0]
-            else:
-                resolution = ruby_yml[pkg]['gentoo'][0]
-                return resolution
-        elif 'gentoo'not in python_yml[pkg]:
-            raise UnresolvedDependency(
-                "could not resolve package {} for Gentoo.".format(pkg))
-        elif 'portage' in python_yml[pkg]['gentoo']:
-            return python_yml[pkg]['gentoo']['portage']['packages'][0]
-        else:
-            resolution = python_yml[pkg]['gentoo'][0]
-            return resolution
-    elif 'gentoo'not in base_yml[pkg]:
+def get_view(os_name, os_version, ros_distro):
+    global view_cache
+    key = os_name + os_version + ros_distro
+    if key not in view_cache:
+        value = get_catkin_view(ros_distro, os_name, os_version, False)
+        view_cache[key] = value
+    return view_cache[key]
+
+
+def resolve_more_for_os(rosdep_key, view, installer, os_name, os_version):
+    """
+    Resolve rosdep key to dependencies and installer key.
+    (This was copied from rosdep2.catkin_support)
+
+    :param os_name: OS name, e.g. 'ubuntu'
+    :returns: resolved key, resolved installer key, and default installer key
+
+    :raises: :exc:`rosdep2.ResolutionError`
+    """
+    d = view.lookup(rosdep_key)
+    ctx = create_default_installer_context()
+    os_installers = ctx.get_os_installer_keys(os_name)
+    default_os_installer = ctx.get_default_os_installer_key(os_name)
+    inst_key, rule = d.get_rule_for_platform(os_name, os_version,
+                                             os_installers,
+                                             default_os_installer)
+    assert inst_key in os_installers
+    return installer.resolve(rule), inst_key, default_os_installer
+
+
+def resolve_rosdep_key(
+    key,
+    os_name,
+    os_version,
+    ros_distro=None,
+    ignored=None,
+    retry=True
+):
+    ignored = ignored or []
+    ctx = create_default_installer_context()
+    try:
+        installer_key = ctx.get_default_os_installer_key(os_name)
+    except KeyError:
+        BloomGenerator.exit("Could not determine the installer for '{0}'"
+                            .format(os_name))
+    installer = ctx.get_installer(installer_key)
+    ros_distro = ros_distro or DEFAULT_ROS_DISTRO
+    view = get_view(os_name, os_version, ros_distro)
+    try:
+        return resolve_more_for_os(key, view, installer, os_name, os_version)
+    except (KeyError, ResolutionError):
         raise UnresolvedDependency(
-            "could not resolve package {} for Gentoo.".format(pkg))
-    elif 'portage' in base_yml[pkg]['gentoo']:
-        resolution = base_yml[pkg]['gentoo']['portage']['packages'][0]
-        return resolution
-    else:
-        resolution = base_yml[pkg]['gentoo'][0]
-        return resolution
+            "could not resolve package {} for {}.".format(key, os_name))


### PR DESCRIPTION
This resolves keys using rosdep instead of parsing the yaml files by hand.

connects to #42, #7 