### PR TITLE
Add `--only PKG` option

### DIFF
--- a/superflore/generate_installers.py
+++ b/superflore/generate_installers.py
@@ -64,7 +64,7 @@ def generate_installers(
             ok('{0}%: {1} \'{2}\'.'.format(percent, success_msg, pkg))
             succeeded = succeeded + 1
             changes.append('*{0} --> {1}*'.format(pkg, version))
-            installers.append(current)
+            installers.append(pkg)
         except KeyError:
             failed_msg = 'Failed to generate installer'
             err("{0}%: {1} for package {2}!".format(percent, failed_msg, pkg))

--- a/superflore/generate_installers.py
+++ b/superflore/generate_installers.py
@@ -1,0 +1,79 @@
+# Copyright 2017 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+
+from rosinstall_generator.distro import get_distro
+from rosinstall_generator.distro import get_package_names
+
+from superflore.exceptions import UnresolvedDependency
+
+from superflore.utils import err
+from superflore.utils import get_pkg_version
+from superflore.utils import ok
+from superflore.utils import warn
+
+
+def generate_installers(distro_name, overlay, gen_pkg, preserve_existing=True):
+    distro = get_distro(distro_name)
+    pkg_names = get_package_names(distro)
+    total = float(len(pkg_names[0]))
+    borkd_pkgs = dict()
+    changes = []
+    installers = []
+    bad_installers = []
+    succeeded = 0
+    failed = 0
+
+    for i, pkg in enumerate(sorted(pkg_names[0])):
+        version = get_pkg_version(distro, pkg)
+        ebuild_name =\
+            '/ros-{0}/{1}/{1}-{2}.ebuild'.format(distro_name, pkg, version)
+        ebuild_name = overlay.repo.repo_dir + ebuild_name
+        ebuild_exists = os.path.exists(ebuild_name)
+        patch_path = '/ros-{}/{}/files'.format(distro_name, pkg)
+        patch_path = overlay.repo.repo_dir + patch_path
+        percent = '%.1f' % (100 * (float(i) / total))
+
+        if preserve_existing and ebuild_exists:
+            skip_msg = 'Ebuild for package '
+            skip_msg += '{0} up to date, skipping...'.format(pkg)
+            status = '{0}%: {1}'.format(percent, skip_msg)
+            ok(status)
+            succeeded = succeeded + 1
+            continue
+        try:
+            current = gen_pkg(overlay=overlay, pkg=pkg, distro=distro)
+            success_msg = 'Successfully generated installer for package'
+            ok('{0}%: {1} \'{2}\'.'.format(percent, success_msg, pkg))
+            succeeded = succeeded + 1
+            changes.append('*{0} --> {1}*'.format(pkg, version))
+            installers.append(current)
+        except (KeyError, UnresolvedDependency):
+            failed_msg = 'Failed to generate installer'
+            err("{0}%: {1} for package {2}!".format(percent, failed_msg, pkg))
+            bad_installers.append(pkg)
+            failed = failed + 1
+    results = 'Generated {0} / {1}'.format(succeeded, failed + succeeded)
+    results += ' for distro {0}'.format(distro_name)
+    print("------ {0} ------".format(results))
+    print()
+
+    if len(borkd_pkgs) > 0:
+        warn("Unresolved:")
+        for broken in borkd_pkgs.keys():
+            warn("{}:".format(broken))
+            warn("  {}".format(borkd_pkgs[broken]))
+
+    return installers, borkd_pkgs, changes

--- a/superflore/generate_installers.py
+++ b/superflore/generate_installers.py
@@ -23,10 +23,10 @@ from superflore.utils import warn
 
 
 def generate_installers(
-    distro_name,      # ros distro name
-    overlay,          # repo instance
-    gen_pkg_func,     # function to call for generating
-    update=True       # are we in update mode?
+    distro_name,            # ros distro name
+    overlay,                # repo instance
+    gen_pkg_func,           # function to call for generating
+    preserve_existing=True  # don't regenerate if installer exists
 ):
     distro = get_distro(distro_name)
     pkg_names = get_package_names(distro)
@@ -44,9 +44,7 @@ def generate_installers(
         percent = '%.1f' % (100 * (float(i) / total))
         try:
             current, bad_deps = gen_pkg_func(
-                overlay, pkg,
-                distro=distro,
-                update=update
+                overlay, pkg, distro, preserve_existing
             )
             if not current and bad_deps:
                 # we are missing dependencies
@@ -56,8 +54,8 @@ def generate_installers(
                 borkd_pkgs[pkg] = bad_deps
                 failed = failed + 1
                 continue
-            elif not current and update:
-                # not an issue if we are in update mode
+            elif not current and preserve_existing:
+                # don't replace the installer
                 succeeded = succeeded + 1
                 continue
             success_msg = 'Successfully generated installer for package'
@@ -72,8 +70,7 @@ def generate_installers(
             failed = failed + 1
     results = 'Generated {0} / {1}'.format(succeeded, failed + succeeded)
     results += ' for distro {0}'.format(distro_name)
-    info("------ {0} ------".format(results))
-    print()
+    info("------ {0} ------\n".format(results))
 
     if len(borkd_pkgs) > 0:
         warn("Unresolved:")

--- a/superflore/generators/ebuild/gen_packages.py
+++ b/superflore/generators/ebuild/gen_packages.py
@@ -26,14 +26,14 @@ from rosinstall_generator.distro import get_package_names
 
 from superflore.exceptions import UnresolvedDependency
 
+from superflore.generators.ebuild.ebuild import Ebuild
+from superflore.generators.ebuild.metadata_xml import metadata_xml
+
 from superflore.utils import err
 from superflore.utils import get_pkg_version
 from superflore.utils import make_dir
 from superflore.utils import ok
 from superflore.utils import warn
-
-from superflore.generators.ebuild.ebuild import Ebuild
-from superflore.generators.ebuild.metadata_xml import metadata_xml
 
 import xmltodict
 
@@ -59,7 +59,6 @@ def regenerate_pkg(overlay, pkg, distro_name=None, distro=None):
     ebuild_name =\
         '/ros-{0}/{1}/{1}-{2}.ebuild'.format(distro_name, pkg, version)
     ebuild_name = overlay.repo.repo_dir + ebuild_name
-    ebuild_exists = os.path.exists(ebuild_name)
     patch_path = '/ros-{}/{}/files'.format(distro_name, pkg)
     patch_path = overlay.repo.repo_dir + patch_path
     has_patches = os.path.exists(patch_path)
@@ -93,10 +92,8 @@ def regenerate_pkg(overlay, pkg, distro_name=None, distro=None):
         dep_err = 'Failed to resolve required dependencies for'
         err("{0} package {1}!".format(dep_err, pkg))
         unresolved = current.ebuild.get_unresolved()
-        borkd_pkgs[pkg] = list()
         for dep in unresolved:
             err(" unresolved: \"{}\"".format(dep))
-            borkd_pkgs[pkg].append(dep)
         err("Failed to generate installer for package {}!".format(pkg))
         raise ud
     except KeyError as ke:
@@ -125,7 +122,6 @@ def regenerate_pkg(overlay, pkg, distro_name=None, distro=None):
         metadata_file.write(metadata_text)
     except Exception as e:
         err("Failed to write ebuild/metadata to disk!")
-        failed_msg = 'Failed to generate installer'
         raise e
     return current
 

--- a/superflore/generators/ebuild/gen_packages.py
+++ b/superflore/generators/ebuild/gen_packages.py
@@ -71,7 +71,7 @@ def get_pkg_version(distro, pkg_name):
     return maj_min_patch
 
 
-def regenerate_pkg(overlay, distro_name=None, distro=None):
+def regenerate_pkg(overlay, pkg, distro_name=None, distro=None):
     if not distro and not distro_name:
         raise RuntimeError('Must supply distro or distro name!')
     elif not distro:
@@ -129,7 +129,7 @@ def regenerate_pkg(overlay, distro_name=None, distro=None):
         "{}/ros-{}/{}".format(overlay.repo.repo_dir, distro_name, pkg)
     )
     success_msg = 'Successfully generated installer for package'
-    ok('{1} \'{2}\'.'.format(success_msg, pkg))
+    ok('{0} \'{1}\'.'.format(success_msg, pkg))
 
     try:
         ebuild_file = '{0}/ros-{1}/{2}/{2}-{3}.ebuild'.format(

--- a/superflore/generators/ebuild/gen_packages.py
+++ b/superflore/generators/ebuild/gen_packages.py
@@ -24,51 +24,20 @@ from rosinstall_generator.distro import _generate_rosinstall
 from rosinstall_generator.distro import get_distro
 from rosinstall_generator.distro import get_package_names
 
-from termcolor import colored
+from superflore.exceptions import UnresolvedDependency
 
-import xmltodict
+from superflore.utils import err
+from superflore.utils import get_pkg_version
+from superflore.utils import make_dir
+from superflore.utils import ok
+from superflore.utils import warn
 
-from .ebuild import Ebuild, UnresolvedDependency
-from .metadata_xml import metadata_xml
+from superflore.generators.ebuild.ebuild import Ebuild
+from superflore.generators.ebuild.metadata_xml import metadata_xml
 
 
 org = "Open Source Robotics Foundation"
 org_license = "BSD"
-
-# TODO(allenh1): This is a blacklist of things that
-# do not yet support Python 3. This will be updated
-# on an as-needed basis until a better solution is
-# found (CI?).
-
-no_python3 = ['tf']
-
-
-def warn(string):
-    print(colored('>>>> {0}'.format(string), 'yellow'))
-
-
-def ok(string):
-    print(colored('>>>> {0}'.format(string), 'green'))
-
-
-def err(string):
-    print(colored('!!!! {0}'.format(string), 'red'))
-
-
-def make_dir(dirname):
-    try:
-        os.makedirs(dirname)
-    except Exception:
-        pass
-
-
-def get_pkg_version(distro, pkg_name):
-    pkg = distro.release_packages[pkg_name]
-    repo = distro.repositories[pkg.repository_name].release_repository
-    maj_min_patch, deb_inc = repo.version.split('-')
-    if deb_inc != '0':
-        return '{0}-r{1}'.format(maj_min_patch, deb_inc)
-    return maj_min_patch
 
 
 def regenerate_pkg(overlay, pkg, distro_name=None, distro=None):

--- a/superflore/generators/ebuild/gen_packages.py
+++ b/superflore/generators/ebuild/gen_packages.py
@@ -86,8 +86,10 @@ def regenerate_pkg(overlay, pkg, distro_name=None, distro=None):
     patch_path = '/ros-{}/{}/files'.format(distro_name, pkg)
     patch_path = overlay.repo.repo_dir + patch_path
     has_patches = os.path.exists(patch_path)
-    installers = []
+    pkg_names = get_package_names(distro)[0]
 
+    if pkg not in pkg_names:
+        raise RuntimeError("Unknown package '%s'" % (pkg))
     # otherwise, remove a (potentially) existing ebuild.
     existing = glob.glob(
         '{0}/ros-{1}/{2}/*.ebuild'.format(
@@ -146,10 +148,9 @@ def regenerate_pkg(overlay, pkg, distro_name=None, distro=None):
         metadata_file.write(metadata_text)
     except Exception as e:
         err("Failed to write ebuild/metadata to disk!")
-        installers.append(current)
         failed_msg = 'Failed to generate installer'
         raise e
-    return installers
+    return current
 
 
 def generate_installers(distro_name, overlay, preserve_existing=True):

--- a/superflore/generators/ebuild/gen_packages.py
+++ b/superflore/generators/ebuild/gen_packages.py
@@ -35,6 +35,14 @@ from superflore.utils import warn
 from superflore.generators.ebuild.ebuild import Ebuild
 from superflore.generators.ebuild.metadata_xml import metadata_xml
 
+import xmltodict
+
+# TODO(allenh1): This is a blacklist of things that
+# do not yet support Python 3. This will be updated
+# on an as-needed basis until a better solution is
+# found (CI?).
+
+no_python3 = ['tf']
 
 org = "Open Source Robotics Foundation"
 org_license = "BSD"

--- a/superflore/generators/ebuild/gen_packages.py
+++ b/superflore/generators/ebuild/gen_packages.py
@@ -75,7 +75,7 @@ def regenerate_pkg(overlay, pkg, distro_name=None, distro=None, update=False):
     )
     if update and existing:
         ok("ebuild for package '%s' up to date, skipping..." % pkg)
-        return None
+        return None, []
     elif existing:
         overlay.repo.remove_file(existing[0])
         manifest_file = '{0}/ros-{1}/{2}/Manifest'.format(
@@ -97,11 +97,9 @@ def regenerate_pkg(overlay, pkg, distro_name=None, distro=None, update=False):
         unresolved = current.ebuild.get_unresolved()
         for dep in unresolved:
             err(" unresolved: \"{}\"".format(dep))
-        err("Failed to generate installer for package {}!".format(pkg))
-        return None, unresolved
+        return None, current.ebuild.get_unresolved()
     except KeyError as ke:
         err("Failed to parse data for package {}!".format(pkg))
-        unresolved = current.ebuild.get_unresolved()
         raise ke
     make_dir(
         "{}/ros-{}/{}".format(overlay.repo.repo_dir, distro_name, pkg)
@@ -125,7 +123,7 @@ def regenerate_pkg(overlay, pkg, distro_name=None, distro=None, update=False):
     except Exception as e:
         err("Failed to write ebuild/metadata to disk!")
         raise e
-    return current
+    return current, []
 
 
 def _gen_metadata_for_package(distro, pkg_name, pkg,

--- a/superflore/generators/ebuild/overlay_instance.py
+++ b/superflore/generators/ebuild/overlay_instance.py
@@ -86,7 +86,7 @@ class RosOverlay(object):
             '/root/.gnupg'
         )
         dock.map_directory(self.repo.repo_dir, '/tmp/ros-overlay')
-        for key in regen_dict:
+        for key in regen_dict.keys():
             for pkg in regen_dict[key]:
                 pkg_dir = '/tmp/ros-overlay/ros-{0}/{1}'.format(key, pkg)
                 dock.add_bash_command('cd {0}'.format(pkg_dir))

--- a/superflore/generators/ebuild/overlay_instance.py
+++ b/superflore/generators/ebuild/overlay_instance.py
@@ -75,7 +75,7 @@ class RosOverlay(object):
         info('Committing to branch {0}...'.format(self.branch_name))
         self.repo.git.commit(m='{0}'.format(commit_msg))
 
-    def regenerate_manifests(self, mode, only_pkg=None):
+    def regenerate_manifests(self, regen_dict):
         info('Building docker image...')
         dock = Docker('repoman_docker', 'gentoo_repoman')
         dock.build()
@@ -86,20 +86,12 @@ class RosOverlay(object):
             '/root/.gnupg'
         )
         dock.map_directory(self.repo.repo_dir, '/tmp/ros-overlay')
-        if only_pkg and isinstance(only_pkg, list):
-            for p in only_pkg:
-                pkg_dir = '/tmp/ros-overlay/ros-{0}/{1}'.format(mode, p)
+        for key in regen_dict:
+            for pkg in regen_dict[key]:
+                pkg_dir = '/tmp/ros-overlay/ros-{0}/{1}'.format(key, pkg)
                 dock.add_bash_command('cd {0}'.format(pkg_dir))
                 dock.add_bash_command('repoman manifest')
                 dock.add_bash_command('cd /tmp/ros-overlay')
-        elif only_pkg:
-            pkg_dir = '/tmp/ros-overlay/ros-{0}/{1}'.format(mode, only_pkg)
-            dock.add_bash_command('cd {0}'.format(pkg_dir))
-            dock.add_bash_command('repoman manifest')
-            dock.add_bash_command('cd /tmp/ros-overlay')
-        else:
-            dock.add_bash_command('cd {0}'.format('/tmp/ros-overlay'))
-            dock.add_bash_command('repoman manifest')
         dock.run(show_cmd=True)
 
     def pull_request(self, message):

--- a/superflore/generators/ebuild/overlay_instance.py
+++ b/superflore/generators/ebuild/overlay_instance.py
@@ -20,10 +20,7 @@ import time
 from superflore.docker import Docker
 from superflore.repo_instance import RepoInstance
 
-from superflore.utils import err
 from superflore.utils import info
-from superflore.utils import ok
-from superflore.utils import warn
 
 
 def get_random_tmp_dir():

--- a/superflore/generators/ebuild/overlay_instance.py
+++ b/superflore/generators/ebuild/overlay_instance.py
@@ -20,6 +20,11 @@ import time
 from superflore.docker import Docker
 from superflore.repo_instance import RepoInstance
 
+from superflore.utils import err
+from superflore.utils import info
+from superflore.utils import ok
+from superflore.utils import warn
+
 
 def get_random_tmp_dir():
     rand_str = ''.join(random.choice(string.ascii_letters) for x in range(10))
@@ -45,25 +50,23 @@ class RosOverlay(object):
         self.branch_name = get_random_branch_name()
         if do_clone:
             self.repo.clone()
-        branch_msg = 'Creating new branch {0}...'.format(self.branch_name)
-        self.repo.info(branch_msg)
+        info('Creating new branch {0}...'.format(self.branch_name))
         self.repo.create_branch(self.branch_name)
 
     def clean_ros_ebuild_dirs(self, distro=None):
-        if distro is not None:
-            self.repo.info('Cleaning up ros-{0} directory...'.format(distro))
+        if distro:
+            info('Cleaning up ros-{0} directory...'.format(distro))
             self.repo.git.rm('-rf', 'ros-{0}'.format(distro))
         else:
-            self.repo.info('Cleaning up ros-* directories...')
+            info('Cleaning up ros-* directories...')
             self.repo.git.rm('-rf', 'ros-*')
 
     def commit_changes(self, distro):
-        self.repo.info('Adding changes...')
-        if not distro:
-            self.repo.git.add('ros-*')
-        else:
+        info('Adding changes...')
+        if distro:
             self.repo.git.add('ros-{0}'.format(distro))
-        if not distro:
+        else:
+            self.repo.git.add('ros-*')
             distro = 'update'
         commit_msg = {
             'update': 'rosdistro sync, {0}',
@@ -72,15 +75,15 @@ class RosOverlay(object):
             'indigo': 'regenerate ros-indigo, {0}',
             'kinetic': 'regenerate ros-kinetic, {0}',
         }[distro].format(time.ctime())
-        self.repo.info('Committing to branch {0}...'.format(self.branch_name))
+        info('Committing to branch {0}...'.format(self.branch_name))
         self.repo.git.commit(m='{0}'.format(commit_msg))
 
     def regenerate_manifests(self, mode, only_pkg=None):
-        self.repo.info('Building docker image...')
+        info('Building docker image...')
         dock = Docker('repoman_docker', 'gentoo_repoman')
         dock.build()
-        self.repo.info('Running docker image...')
-        self.repo.info('Generating manifests...')
+        info('Running docker image...')
+        info('Generating manifests...')
         dock.map_directory(
             '/home/%s/.gnupg' % os.getenv('USER'),
             '/root/.gnupg'

--- a/superflore/generators/ebuild/run.py
+++ b/superflore/generators/ebuild/run.py
@@ -19,9 +19,11 @@ import shutil
 import sys
 import time
 
-from superflore.generators.ebuild.gen_packages import generate_installers
+from superflore.generate_installers import generate_installers
+
 from superflore.generators.ebuild.gen_packages import regenerate_pkg
 from superflore.generators.ebuild.overlay_instance import RosOverlay
+
 from superflore.repo_instance import RepoInstance
 
 from superflore.utils import err
@@ -168,7 +170,12 @@ def main():
 
     for distro in selected_targets:
         distro_installers, distro_broken, distro_changes =\
-            generate_installers(distro, overlay, preserve_existing)
+            generate_installers(
+                distro_name=distro,
+                overlay=overlay,
+                gen_pkg=regenerate_pkg,
+                preserve_existing=preserve_existing
+            )
         for key in distro_broken.keys():
             for pkg in distro_broken[key]:
                 total_broken.add(pkg)

--- a/superflore/generators/ebuild/run.py
+++ b/superflore/generators/ebuild/run.py
@@ -151,7 +151,9 @@ def main():
             distro_name=args.ros_distro
         )
         # Commit changes and file pull request
-        overlay.regenerate_manifests(args.ros_distro, only_pkg=args.only)
+        regen_dict = dict()
+        regen_dict[args.ros_distro] = [].append(args.only)
+        overlay.regenerate_manifests()
         overlay.commit_changes(args.ros_distro)
         delta = "Regenerated: '%s'\n" % args.only
         missing_deps = ''
@@ -232,7 +234,7 @@ def main():
             missing_deps += " * [ ] {0}\n".format(pkg)
 
     # Commit changes and file pull request
-    overlay.regenerate_manifests(args.ros_distro)
+    overlay.regenerate_manifests(total_installers)
     overlay.commit_changes(args.ros_distro)
 
     if args.dry_run:

--- a/superflore/generators/ebuild/run.py
+++ b/superflore/generators/ebuild/run.py
@@ -20,6 +20,7 @@ import sys
 import time
 
 from superflore.generators.ebuild.gen_packages import generate_installers
+from superflore.generators.ebuild.gen_packages import regenerate_pkg
 from superflore.generators.ebuild.overlay_instance import RosOverlay
 from superflore.repo_instance import RepoInstance
 
@@ -137,11 +138,16 @@ def main():
 
     if args.only:
         RepoInstance.info("Regenerating package '%s'..." % args.only)
-        installers = regenerate_pkg(overlay, args.ros_distro)
+        installers = regenerate_pkg(
+            overlay,
+            pkg=args.only,
+            distro_name=args.ros_distro
+        )
         # Commit changes and file pull request
-        overlay.regenerate_manifests(args.ros_distro)
+        overlay.regenerate_manifests(args.ros_distro, only_pkg=args.only)
         overlay.commit_changes(args.ros_distro)
-
+        delta = "Regenerated: '%s'\n" % args.only
+        missing_deps=''
         if args.dry_run:
             RepoInstance.info('Running in dry mode, not filing PR')
             title_file = open('.pr-title.tmp', 'w')

--- a/superflore/generators/ebuild/run.py
+++ b/superflore/generators/ebuild/run.py
@@ -53,8 +53,8 @@ def file_pr(overlay, delta, missing_deps):
     try:
         overlay.pull_request('{0}\n{1}'.format(delta, missing_deps))
     except Exception as e:
-        overlay.error('Failed to file PR with ros/ros-overlay repo!')
-        overlay.error('Exception: {0}'.format(e))
+        err('Failed to file PR with ros/ros-overlay repo!')
+        err('Exception: {0}'.format(e))
         sys.exit(1)
 
 
@@ -103,10 +103,10 @@ def main():
         selected_targets = [args.ros_distro]
         preserve_existing = False
     elif args.dry_run and args.pr_only:
-        error('Invalid args! cannot dry-run and file PR')
+        err('Invalid args! cannot dry-run and file PR')
         sys.exit(1)
     elif args.pr_only and not args.output_repository_path:
-        error('Invalid args! no repository specified')
+        err('Invalid args! no repository specified')
     elif args.pr_only:
         try:
             with open('.pr-message.tmp', 'r') as msg_file:
@@ -114,8 +114,8 @@ def main():
             with open('.pr-title.tmp', 'r') as title_file:
                 title = title_file.read().rstrip('\n')
         except OSError:
-            error('Failed to open PR title/message file!')
-            error(
+            err('Failed to open PR title/message file!')
+            err(
                 'Please supply the %s and %s files' % (
                     '.pr_message.tmp',
                     '.pr_title.tmp'
@@ -130,8 +130,8 @@ def main():
             clean_up('all')
             sys.exit(0)
         except Exception as e:
-            error('Failed to file PR!')
-            error('reason: {0}'.format(e))
+            err('Failed to file PR!')
+            err('reason: {0}'.format(e))
             sys.exit(1)
     # clone current repo
     overlay = RosOverlay(args.output_repository_path)
@@ -143,7 +143,7 @@ def main():
 
     if args.only:
         info("Regenerating package '%s'..." % args.only)
-        installers = regenerate_pkg(
+        regenerate_pkg(
             overlay,
             pkg=args.only,
             distro_name=args.ros_distro
@@ -152,7 +152,7 @@ def main():
         overlay.regenerate_manifests(args.ros_distro, only_pkg=args.only)
         overlay.commit_changes(args.ros_distro)
         delta = "Regenerated: '%s'\n" % args.only
-        missing_deps=''
+        missing_deps = ''
         if args.dry_run:
             info('Running in dry mode, not filing PR')
             title_file = open('.pr-title.tmp', 'w')

--- a/superflore/generators/ebuild/run.py
+++ b/superflore/generators/ebuild/run.py
@@ -152,8 +152,8 @@ def main():
         )
         # Commit changes and file pull request
         regen_dict = dict()
-        regen_dict[args.ros_distro] = [].append(args.only)
-        overlay.regenerate_manifests()
+        regen_dict[args.ros_distro] = [args.only]
+        overlay.regenerate_manifests(regen_dict)
         overlay.commit_changes(args.ros_distro)
         delta = "Regenerated: '%s'\n" % args.only
         missing_deps = ''

--- a/superflore/generators/ebuild/run.py
+++ b/superflore/generators/ebuild/run.py
@@ -173,8 +173,8 @@ def main():
             generate_installers(
                 distro_name=distro,
                 overlay=overlay,
-                gen_pkg=regenerate_pkg,
-                preserve_existing=preserve_existing
+                gen_pkg_func=regenerate_pkg,
+                update=preserve_existing
             )
         for key in distro_broken.keys():
             for pkg in distro_broken[key]:

--- a/superflore/generators/ebuild/run.py
+++ b/superflore/generators/ebuild/run.py
@@ -19,6 +19,8 @@ import shutil
 import sys
 import time
 
+from rosinstall_generator.distro import get_distro
+
 from superflore.generate_installers import generate_installers
 
 from superflore.generators.ebuild.gen_packages import regenerate_pkg
@@ -148,7 +150,7 @@ def main():
         regenerate_pkg(
             overlay,
             pkg=args.only,
-            distro_name=args.ros_distro
+            distro=get_distro(args.ros_distro)
         )
         # Commit changes and file pull request
         regen_dict = dict()
@@ -176,7 +178,7 @@ def main():
                 distro_name=distro,
                 overlay=overlay,
                 gen_pkg_func=regenerate_pkg,
-                update=preserve_existing
+                preserve_existing=preserve_existing
             )
         for key in distro_broken.keys():
             for pkg in distro_broken[key]:

--- a/superflore/generators/ebuild/run.py
+++ b/superflore/generators/ebuild/run.py
@@ -94,8 +94,8 @@ def main():
     )
     parser.add_argument(
         '--only',
-        help='generate only the specified package',
-        type=str
+        nargs='+',
+        help='generate only the specified packages'
     )
 
     args = parser.parse_args(sys.argv[1:])
@@ -146,15 +146,16 @@ def main():
     total_changes = dict()
 
     if args.only:
-        info("Regenerating package '%s'..." % args.only)
-        regenerate_pkg(
-            overlay,
-            pkg=args.only,
-            distro=get_distro(args.ros_distro)
-        )
+        for pkg in args.only:
+            info("Regenerating package '%s'..." % pkg)
+            regenerate_pkg(
+                overlay,
+                pkg=pkg,
+                distro=get_distro(args.ros_distro)
+            )
         # Commit changes and file pull request
         regen_dict = dict()
-        regen_dict[args.ros_distro] = [args.only]
+        regen_dict[args.ros_distro] = args.only
         overlay.regenerate_manifests(regen_dict)
         overlay.commit_changes(args.ros_distro)
         delta = "Regenerated: '%s'\n" % args.only

--- a/superflore/repo_instance.py
+++ b/superflore/repo_instance.py
@@ -17,10 +17,9 @@ import shutil
 from git import Repo
 from git.exc import GitCommandError as GitGotGot
 
-from superflore.utils import err
+from superflore.utils import err as error
 from superflore.utils import info
 from superflore.utils import ok
-from superflore.utils import warn
 
 
 class RepoInstance(object):

--- a/superflore/repo_instance.py
+++ b/superflore/repo_instance.py
@@ -17,7 +17,10 @@ import shutil
 from git import Repo
 from git.exc import GitCommandError as GitGotGot
 
-from termcolor import colored
+from superflore.utils import err
+from superflore.utils import info
+from superflore.utils import ok
+from superflore.utils import warn
 
 
 class RepoInstance(object):
@@ -41,7 +44,7 @@ class RepoInstance(object):
         msg += '...'
         RepoInstance.info(msg)
         self.repo = Repo.clone_from(self.repo_url, self.repo_dir)
-        if branch is not None:
+        if branch:
             self.git.checkout(branch)
 
     def remove_file(self, filename, ignore_fail=False):
@@ -52,14 +55,14 @@ class RepoInstance(object):
                 return
             fail_msg = 'Failed to remove file {0}'.format(filename)
             fail_msg += 'from source control.'
-            self.error(fail_msg)
-            self.error(' Exception: {0}'.format(g))
+            error(fail_msg)
+            error(' Exception: {0}'.format(g))
 
     def create_branch(self, branch_name):
         """
         @todo: error checking
         """
-        RepoInstance.info(self.git.checkout('HEAD', b=branch_name))
+        info(self.git.checkout('HEAD', b=branch_name))
 
     def remove_branch(self, branch_name):
         """
@@ -80,27 +83,10 @@ class RepoInstance(object):
         self.git.rebase(i=target)
 
     def pull_request(self, message, title):
-        self.info('Filing pull-request...')
+        info('Filing pull-request...')
         self.git.pull_request(m='{0}'.format(message),
                               title='{0}'.format(title))
-        good_msg = 'Successfully filed a pull request.'
-        self.happy(good_msg)
-
-    @staticmethod
-    def info(string):
-        print(colored(string, 'cyan'))
-
-    @staticmethod
-    def error(string):
-        print(colored(string, 'red'))
-
-    @staticmethod
-    def warn(string):
-        print(colored(string, 'yellow'))
-
-    @staticmethod
-    def happy(string):
-        print(colored(string, 'green'))
+        ok('Successfully filed a pull request.')
 
 
 class CloneException(Exception):

--- a/superflore/repo_instance.py
+++ b/superflore/repo_instance.py
@@ -42,7 +42,7 @@ class RepoInstance(object):
         if self.repo_dir != self.repo_name:
             msg += (' into directory {0}'.format(self.repo_dir))
         msg += '...'
-        RepoInstance.info(msg)
+        info(msg)
         self.repo = Repo.clone_from(self.repo_url, self.repo_dir)
         if branch:
             self.git.checkout(branch)

--- a/superflore/utils.py
+++ b/superflore/utils.py
@@ -55,8 +55,11 @@ def info(string):
 def make_dir(dirname):
     try:
         os.makedirs(dirname)
-    except:
-        pass
+    except OSError as e:
+        if e.errno == errno.EEXIST and os.path.isdir(dirname):
+            pass
+        else:
+            raise e
 
 
 def get_pkg_version(distro, pkg_name):

--- a/superflore/utils.py
+++ b/superflore/utils.py
@@ -36,14 +36,6 @@ else:
         return response.read()
 
 
-# TODO(allenh1): This is a blacklist of things that
-# do not yet support Python 3. This will be updated
-# on an as-needed basis until a better solution is
-# found (CI?).
-
-no_python3 = ['tf']
-
-
 def warn(string):
     print(colored('>>>> {0}'.format(string), 'yellow'))
 

--- a/superflore/utils.py
+++ b/superflore/utils.py
@@ -36,6 +36,46 @@ else:
         return response.read()
 
 
+# TODO(allenh1): This is a blacklist of things that
+# do not yet support Python 3. This will be updated
+# on an as-needed basis until a better solution is
+# found (CI?).
+
+no_python3 = ['tf']
+
+
+def warn(string):
+    print(colored('>>>> {0}'.format(string), 'yellow'))
+
+
+def ok(string):
+    print(colored('>>>> {0}'.format(string), 'green'))
+
+
+def err(string):
+    print(colored('!!!! {0}'.format(string), 'red'))
+
+
+def info(string):
+    print(colored('>>> {0}'.format(string), 'cyan'))
+
+
+def make_dir(dirname):
+    try:
+        os.makedirs(dirname)
+    except:
+        pass
+
+
+def get_pkg_version(distro, pkg_name):
+    pkg = distro.release_packages[pkg_name]
+    repo = distro.repositories[pkg.repository_name].release_repository
+    maj_min_patch, deb_inc = repo.version.split('-')
+    if deb_inc != '0':
+        return '{0}-r{1}'.format(maj_min_patch, deb_inc)
+    return maj_min_patch
+
+
 def download_yamls():
     global base_yml
     global python_yml
@@ -46,11 +86,11 @@ def download_yamls():
     python_yaml = "{0}/python.yaml".format(base_url)
     ruby_yaml = "{0}/ruby.yaml".format(base_url)
 
-    print(colored("Downloading latest base yml...", 'cyan'))
+    info("Downloading latest base yml...")
     base_yml = yaml.load(get_http(base_yaml))
-    print(colored("Downloading latest python yml...", 'cyan'))
+    info("Downloading latest python yml...", 'cyan')
     python_yml = yaml.load(get_http(python_yaml))
-    print(colored("Downloading latest ruby yml...", 'cyan'))
+    info("Downloading latest ruby yml...", 'cyan')
     ruby_yml = yaml.load(get_http(ruby_yaml))
 
 

--- a/superflore/utils.py
+++ b/superflore/utils.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import errno
+import os
 import re
 import sys
 


### PR DESCRIPTION
This set of changes adds an option to generate a single package by name, and will also include a refactor of `generate_packages.py` so that it can be relocated outside the `ebuild` folder (this will eliminate a lot of redundancy).

ToDo:
---------
 * [x] add the `--only PKG` flag to generate a single package
 * [x] refactor & separate gentoo-specific logic
 * [x] modify `regenerate_manifests` to only regenerate changed packages