### PR TITLE
Add stdeb.cfg

### DIFF
--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -1,0 +1,4 @@
+[DEFAULT]
+Depends: python3-rospkg (>= 1.0.37), python3-yaml, python3-catkin-pkg, python3-rosdistro (>= 0.4.0), python3-termcolor, python3-xmltodict python3-rosinstall-generator, python3-rosdep, python3-requests, git, docker-engine
+Suite: oneiric precise quantal raring saucy trusty utopic vivid wily xenial yakkety zesty artful wheezy jessie stretch
+X-Python3-Version: >= 3.2


### PR DESCRIPTION
@tfoote There's a couple of dependencies I'm not sure how to handle.

* `python3-docker`: the pip version is 2.5, and the Ubuntu version is 1.9. You mentioned they were pretty different? Should I be concerned?
* `git-pull-request`: the python library lacks a `.deb` installer. Do I mark it as a pip installed thing somehow?

connects to ros-infrastructure/superflore#65