### PR TITLE
Add an install for the dockerfile.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,8 @@ setup(
     description='Super Bloom',
     license='Apache 2.0',
     test_suite='tests',
+    data_files=[('repoman_docker', ['repoman_docker/Dockerfile'])],
+    include_package_data = True,
     entry_points={
         'console_scripts' : [
             'superflore-gen-ebuilds = superflore.generators.ebuild:main',

--- a/superflore/docker.py
+++ b/superflore/docker.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 import os
-import docker
 
+import docker
 from superflore.utils import info
 from superflore.utils import ok
 

--- a/superflore/docker.py
+++ b/superflore/docker.py
@@ -20,9 +20,9 @@ from superflore.utils import ok
 
 
 class Docker(object):
-    def __init__(self, dockerfile_directory, name):
+    def __init__(self, dockerfile, name):
         self.client = docker.from_env()
-        self.dockerfile_directory = os.path.dirname(dockerfile_directory)
+        self.dockerfile_directory = os.path.dirname(dockerfile)
         self.name = name
         self.image = None
         self.directory_map = dict()

--- a/superflore/docker.py
+++ b/superflore/docker.py
@@ -12,11 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import docker
 import os
+import docker
+
 from superflore.utils import info
 from superflore.utils import ok
-from superflore.utils import warn
 
 
 class Docker(object):

--- a/superflore/docker.py
+++ b/superflore/docker.py
@@ -13,14 +13,16 @@
 # limitations under the License.
 
 import docker
+import os
 from superflore.utils import info
 from superflore.utils import ok
+from superflore.utils import warn
 
 
 class Docker(object):
     def __init__(self, dockerfile_directory, name):
         self.client = docker.from_env()
-        self.dockerfile_directory = dockerfile_directory
+        self.dockerfile_directory = os.path.dirname(dockerfile_directory)
         self.name = name
         self.image = None
         self.directory_map = dict()

--- a/superflore/generators/ebuild/overlay_instance.py
+++ b/superflore/generators/ebuild/overlay_instance.py
@@ -46,7 +46,7 @@ class RosOverlay(object):
 
     def regenerate_manifests(self, regen_dict):
         info('Building docker image...')
-        docker_file = resource_filename(__name__, 'Dockerfile')
+        docker_file = resource_filename('repoman_docker', 'Dockerfile')
         dock = Docker(docker_file, 'gentoo_repoman')
         dock.build()
         info('Running docker image...')

--- a/superflore/generators/ebuild/overlay_instance.py
+++ b/superflore/generators/ebuild/overlay_instance.py
@@ -15,6 +15,7 @@
 import os
 import time
 
+from pkg_resources import resource_filename
 from superflore.docker import Docker
 from superflore.repo_instance import RepoInstance
 from superflore.utils import info
@@ -45,7 +46,8 @@ class RosOverlay(object):
 
     def regenerate_manifests(self, regen_dict):
         info('Building docker image...')
-        dock = Docker('repoman_docker', 'gentoo_repoman')
+        docker_file = resource_filename(__name__, 'Dockerfile')
+        dock = Docker(docker_file, 'gentoo_repoman')
         dock.build()
         info('Running docker image...')
         info('Generating manifests...')


### PR DESCRIPTION
This _should_ tell setup.py to install the dockerfile (so that we can have it in a central location and not run superflore from the source directory).

But I'm not sure where the file goes exactly?

> Each (directory, files) pair in the sequence specifies the installation directory and the files to install there. If directory is a relative path, it is interpreted relative to the installation prefix (Python’s sys.prefix for pure-Python packages, sys.exec_prefix for packages that contain extension modules). Each file name in files is interpreted relative to the setup.py script at the top of the package source distribution. No directory information from files is used to determine the final location of the installed file; only the name of the file is used.

This is from the [Python documentation](https://docs.python.org/3/distutils/setupscript.html#installing-additional-files).

@tfoote Do you know how one goes about referencing these files/if this is a proper way to do this?