### PR TITLE
Drop python 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-  - "2.7"
   - "3.4"
   - "3.5"
   # PyPy versions

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ python:
   - "3.4"
   - "3.5"
   # PyPy versions
-  - "pypy"
+  - "pypy3"
 before_install:
   - sudo echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" | sudo tee -a /etc/apt/sources.list.d/ros-latest.list
   - sudo apt-key adv --keyserver hkp://ha.pool.sks-keyservers.net:80 --recv-key 421C365BD9FF1F717815A3895523BAEEB01FA116

--- a/setup.py
+++ b/setup.py
@@ -16,9 +16,6 @@ install_requires = [
     'docker'
 ]
 
-if sys.version_info[0] == 2 and sys.version_info[1] <= 6:
-    install_requires.append('argparse')
-
 setup(
     name='superflore',
     version='0.1.0',

--- a/superflore/__init__.py
+++ b/superflore/__init__.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 try:
     import pkg_resources
     try:

--- a/superflore/generators/bitbake/yocto_recipe.py
+++ b/superflore/generators/bitbake/yocto_recipe.py
@@ -29,17 +29,10 @@ import os.path
 import tarfile
 
 from superflore.exceptions import NoPkgXml
+from superflore.utils import get_http
 from superflore.utils import get_pkg_version
 from superflore.utils import info
 from superflore.utils import resolve_dep
-
-from urllib.request import urlopen
-import urllib
-
-
-def get_http(url):
-    response = urlopen(url)
-    return response.read()
 
 
 class yoctoRecipe(object):

--- a/superflore/generators/bitbake/yocto_recipe.py
+++ b/superflore/generators/bitbake/yocto_recipe.py
@@ -25,14 +25,13 @@
 
 import hashlib
 import os.path
-
 import tarfile
+from urllib.request import urlretrieve
 
 from superflore.exceptions import NoPkgXml
 from superflore.utils import get_pkg_version
 from superflore.utils import info
 from superflore.utils import resolve_dep
-from urllib.request import urlretrieve
 
 
 class yoctoRecipe(object):

--- a/superflore/generators/bitbake/yocto_recipe.py
+++ b/superflore/generators/bitbake/yocto_recipe.py
@@ -29,10 +29,10 @@ import os.path
 import tarfile
 
 from superflore.exceptions import NoPkgXml
-from superflore.utils import get_http
 from superflore.utils import get_pkg_version
 from superflore.utils import info
 from superflore.utils import resolve_dep
+from urllib.request import urlretrieve
 
 
 class yoctoRecipe(object):
@@ -86,7 +86,7 @@ class yoctoRecipe(object):
             info("using cached archive for package '%s'..." % self.name)
         else:
             info("downloading archive version for package '%s'..." % self.name)
-            urllib.request.urlretrieve(self.src_uri, self.getArchiveName())
+            urlretrieve(self.src_uri, self.getArchiveName())
 
     def extractArchive(self):
         tar = tarfile.open(self.getArchiveName(), "r:gz")

--- a/superflore/generators/bitbake/yocto_recipe.py
+++ b/superflore/generators/bitbake/yocto_recipe.py
@@ -25,7 +25,7 @@
 
 import hashlib
 import os.path
-import sys
+
 import tarfile
 
 from superflore.exceptions import NoPkgXml
@@ -33,19 +33,13 @@ from superflore.utils import get_pkg_version
 from superflore.utils import info
 from superflore.utils import resolve_dep
 
-if sys.version_info[0] == 2:
-    import requests
-    import urllib
+from urllib.request import urlopen
+import urllib
 
-    def get_http(url):
-        return requests.get(url).text
-else:
-    from urllib.request import urlopen
-    import urllib
 
-    def get_http(url):
-        response = urlopen(url)
-        return response.read()
+def get_http(url):
+    response = urlopen(url)
+    return response.read()
 
 
 class yoctoRecipe(object):

--- a/superflore/generators/ebuild/ebuild.py
+++ b/superflore/generators/ebuild/ebuild.py
@@ -110,14 +110,11 @@ class Ebuild(object):
         ret += "inherit ros-cmake\n\n"
 
         # description, homepage, src_uri
-        py_v = sys.version_info
         self.description =\
             sanitize_string(self.description, self.illegal_desc_chars)
         self.description = trim_string(self.description)
         if isinstance(self.description, str):
             ret += "DESCRIPTION=\"" + self.description + "\"\n"
-        elif py_v <= (3, 0):
-            ret += "DESCRIPTION=\"" + self.description.decode() + "\"\n"
         else:
             ret += "DESCRIPTION=\"NONE\"\n"
 
@@ -132,19 +129,6 @@ class Ebuild(object):
                 ret += 'LICENSE="( '
                 ret += ' '.join([get_license(l) for l in split])
                 ret += ') "\n'
-            else:
-                ret += "LICENSE=\""
-                ret += get_license(self.upstream_license) + "\"\n\n"
-        elif py_v < (3, 0):
-            self.upstream_license = self.upstream_license.decode()
-            split = self.upstream_license.split(',')
-            if len(split) > 1:
-                # they did something like "BSD,GPL,blah"
-                ret += 'LICENSE="( '
-                ret += ' '.join(
-                    [get_license(l.replace(' ', '')) for l in split]
-                )
-                ret += ' )"\n'
             else:
                 ret += "LICENSE=\""
                 ret += get_license(self.upstream_license) + "\"\n\n"

--- a/superflore/generators/ebuild/ebuild.py
+++ b/superflore/generators/ebuild/ebuild.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import sys
-
 from superflore.exceptions import UnresolvedDependency
 from superflore.utils import get_license
 from superflore.utils import resolve_dep

--- a/superflore/generators/ebuild/ebuild.py
+++ b/superflore/generators/ebuild/ebuild.py
@@ -111,11 +111,7 @@ class Ebuild(object):
         self.description =\
             sanitize_string(self.description, self.illegal_desc_chars)
         self.description = trim_string(self.description)
-        if isinstance(self.description, str):
-            ret += "DESCRIPTION=\"" + self.description + "\"\n"
-        else:
-            ret += "DESCRIPTION=\"NONE\"\n"
-
+        ret += "DESCRIPTION=\"" + self.description + "\"\n"
         ret += "HOMEPAGE=\"" + self.homepage + "\"\n"
         ret += "SRC_URI=\"" + self.src_uri
         ret += " -> ${PN}-" + self.distro + "-release-${PV}.tar.gz\"\n\n"

--- a/superflore/generators/ebuild/gen_packages.py
+++ b/superflore/generators/ebuild/gen_packages.py
@@ -14,7 +14,6 @@
 
 import glob
 import os
-import sys
 
 from rosdistro.dependency_walker import DependencyWalker
 from rosdistro.manifest_provider import get_release_tag

--- a/superflore/generators/ebuild/gen_packages.py
+++ b/superflore/generators/ebuild/gen_packages.py
@@ -199,8 +199,6 @@ def _gen_ebuild_for_package(distro, pkg_name, pkg,
     try:
         if 'url' not in pkg_fields['package']:
             warn("no website field for package {}".format(pkg_name))
-        elif sys.version_info <= (3, 0):
-            pkg_ebuild.homepage = pkg_fields['package']['url'].decode()
         elif isinstance(pkg_fields['package']['url'], str):
             pkg_ebuild.homepage = pkg_fields['package']['url']
         elif '@type' in pkg_fields['package']['url']:

--- a/superflore/utils.py
+++ b/superflore/utils.py
@@ -17,7 +17,6 @@ import os
 import random
 import re
 import string
-import sys
 
 from superflore.exceptions import UnknownLicense
 from superflore.exceptions import UnknownPlatform

--- a/superflore/utils.py
+++ b/superflore/utils.py
@@ -18,11 +18,12 @@ import random
 import re
 import string
 
+from urllib.request import urlopen
 from superflore.exceptions import UnknownLicense
 from superflore.exceptions import UnknownPlatform
 from superflore.rosdep_support import resolve_rosdep_key
 from termcolor import colored
-from urllib.request import urlopen
+
 import yaml
 
 

--- a/superflore/utils.py
+++ b/superflore/utils.py
@@ -17,14 +17,12 @@ import os
 import random
 import re
 import string
-
 from urllib.request import urlopen
 
 from superflore.exceptions import UnknownLicense
 from superflore.exceptions import UnknownPlatform
 from superflore.rosdep_support import resolve_rosdep_key
 from termcolor import colored
-
 import yaml
 
 

--- a/superflore/utils.py
+++ b/superflore/utils.py
@@ -19,6 +19,7 @@ import re
 import string
 
 from urllib.request import urlopen
+
 from superflore.exceptions import UnknownLicense
 from superflore.exceptions import UnknownPlatform
 from superflore.rosdep_support import resolve_rosdep_key

--- a/superflore/utils.py
+++ b/superflore/utils.py
@@ -23,19 +23,13 @@ from superflore.exceptions import UnknownLicense
 from superflore.exceptions import UnknownPlatform
 from superflore.rosdep_support import resolve_rosdep_key
 from termcolor import colored
+from urllib.request import urlopen
 import yaml
 
-if sys.version_info[0] == 2:
-    import requests
 
-    def get_http(url):
-        return requests.get(url).text
-else:
-    from urllib.request import urlopen
-
-    def get_http(url):
-        response = urlopen(url)
-        return response.read()
+def get_http(url):
+    response = urlopen(url)
+    return response.read()
 
 
 def warn(string):
@@ -167,7 +161,7 @@ def get_license(l):
     elif re.search(pub_dom_re, l, f):
         return 'public_domain'
     else:
-        print(colored('Could not match license "{0}".'.format(l), 'red'))
+        err('Could not match license "{0}".'.format(l), 'red')
         raise UnknownLicense('bad license')
 
 


### PR DESCRIPTION
This drops support for Python 2, since the `git-pull-request` utility doesn't work with Python 2.