### PR TITLE
Add missing '>' to info message.

### DIFF
--- a/superflore/utils.py
+++ b/superflore/utils.py
@@ -44,7 +44,7 @@ def err(string):
 
 
 def info(string):
-    print(colored('>>> {0}'.format(string), 'cyan'))
+    print(colored('>>>> {0}'.format(string), 'cyan'))
 
 
 def make_dir(dirname):


### PR DESCRIPTION
Not anything _that_ important, but I noticed this generating a new set of Open Embedded recipes earlier.