### PR TITLE
Replace vars where possible

### DIFF
--- a/superflore/generators/bitbake/yocto_recipe.py
+++ b/superflore/generators/bitbake/yocto_recipe.py
@@ -165,6 +165,7 @@ class yoctoRecipe(object):
         ret += '"\n'
 
         # SRC_URI
+        self.src_uri = self.src_uri.replace(self.name, '${PN}')
         ret += 'SRC_URI = "' + self.src_uri + ';'
         ret += 'downloadfilename=${ROS_SP}.tar.gz"\n\n'
         ret += 'SRC_URI[md5sum] = "' + self.src_md5 + '"\n'

--- a/superflore/generators/ebuild/ebuild.py
+++ b/superflore/generators/ebuild/ebuild.py
@@ -114,6 +114,7 @@ class Ebuild(object):
         self.description = trim_string(self.description)
         ret += "DESCRIPTION=\"" + self.description + "\"\n"
         ret += "HOMEPAGE=\"" + self.homepage + "\"\n"
+        self.src_uri = self.src_uri.replace(self.name, '${PN}')
         ret += "SRC_URI=\"" + self.src_uri
         ret += " -> ${PN}-" + self.distro + "-release-${PV}.tar.gz\"\n\n"
         # license -- only add if valid

--- a/tests/ebuild/simple_expected.ebuild
+++ b/tests/ebuild/simple_expected.ebuild
@@ -8,7 +8,7 @@ inherit ros-cmake
 
 DESCRIPTION="an ebuild"
 HOMEPAGE="https://www.website.com"
-SRC_URI="https://www.website.com/download/stuff.tar.gz -> ${PN}-lunar-release-${PV}.tar.gz"
+SRC_URI="https://www.website.com/download/${PN}/archive/${PN}/release/lunar/0.0.0.tar.gz -> ${PN}-lunar-release-${PV}.tar.gz"
 
 LICENSE="LGPL-2"
 

--- a/tests/test_ebuild.py
+++ b/tests/test_ebuild.py
@@ -26,7 +26,8 @@ class TestEbuildOutput(unittest.TestCase):
         ebuild = Ebuild()
         ebuild.homepage = 'https://www.website.com'
         ebuild.description = 'an ebuild'
-        ebuild.src_uri = 'https://www.website.com/download/stuff.tar.gz'
+        ebuild.src_uri = 'https://www.website.com/download/foo/archive/foo/release/lunar/0.0.0.tar.gz'
+        ebuild.name = 'foo'
         ebuild.distro = 'lunar'
         return ebuild
 


### PR DESCRIPTION
This just allows for fewer characters to be present in the ebuilds/recipes, and is more Gentoo/Yocto-esque.