### PR TITLE
Fix existing version detection.

### DIFF
--- a/superflore/generators/ebuild/gen_packages.py
+++ b/superflore/generators/ebuild/gen_packages.py
@@ -60,7 +60,7 @@ def regenerate_pkg(overlay, pkg, distro, preserve_existing=False):
             distro.name, pkg
         )
     )
-    if preserve_existing and existing:
+    if preserve_existing and os.path.isfile(ebuild_name):
         ok("ebuild for package '%s' up to date, skipping..." % pkg)
         return None, []
     elif existing:


### PR DESCRIPTION
As pointed out in ros/ros-overlay#279 by @flabrose, the `gpsd_client` packages were out of date.

This would explain why. I'm decently red in the face for not noticing this sooner.

