### PR TITLE
Add `--only [pkg_1] [pkg_2] ... [pkg_n]`

### DIFF
--- a/superflore/generators/ebuild/run.py
+++ b/superflore/generators/ebuild/run.py
@@ -142,12 +142,16 @@ def main():
         if args.only:
             for pkg in args.only:
                 info("Regenerating package '%s'..." % pkg)
-                regenerate_pkg(
-                    overlay,
-                    pkg,
-                    get_distro(args.ros_distro),
-                    preserve_existing
-                )
+                try:
+                    regenerate_pkg(
+                        overlay,
+                        pkg,
+                        get_distro(args.ros_distro),
+                        preserve_existing
+                    )
+                except KeyError:
+                    erro("No package to satisfy key '%s'" % pkg)
+                    sys.exit(1)
             # Commit changes and file pull request
             regen_dict = dict()
             regen_dict[args.ros_distro] = args.only

--- a/superflore/generators/ebuild/run.py
+++ b/superflore/generators/ebuild/run.py
@@ -150,7 +150,7 @@ def main():
                         preserve_existing
                     )
                 except KeyError:
-                    erro("No package to satisfy key '%s'" % pkg)
+                    err("No package to satisfy key '%s'" % pkg)
                     sys.exit(1)
             # Commit changes and file pull request
             regen_dict = dict()


### PR DESCRIPTION
This adds the `--only [pkg_1] [pkg_2] ... [pkg_n]` argument to `superflore-gen-meta-pkgs`.

We also handle a `KeyError` exception in more graceful way than a backtrace.