### PR TITLE
Docker tests

### DIFF
--- a/tests/test_docker.py
+++ b/tests/test_docker.py
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from time import gmtime, strftime
-import re
+from pkg_resources import resource_filename
+from superflore.docker import Docker
+import unittest
 
-from superflore.docker import docker
 class TestDocker(unittest.TestCase):
     def get_image(self):
         docker_file = resource_filename('repoman_docker', 'Dockerfile')
@@ -23,9 +23,31 @@ class TestDocker(unittest.TestCase):
         return dock
 
     def test_init(self):
-        docker_instance = get_image()
+        docker_instance = self.get_image()
         self.assertTrue(docker_instance.client)
         self.assertEqual(docker_instance.name, 'gentoo_repoman')
         self.assertEqual(docker_instance.image, None)
         self.assertEqual(docker_instance.directory_map, dict())
 
+    def test_map_dir(self):
+        docker_instance = self.get_image()
+        docker_instance.map_directory('/tmp/host', '/tmp/container')
+        tmp = dict()
+        tmp['/tmp/host'] = dict()
+        tmp['/tmp/host']['bind'] = '/tmp/container'
+        tmp['/tmp/host']['mode'] = 'rw'
+        self.assertEqual(docker_instance.directory_map, tmp)
+        docker_instance = self.get_image()
+        docker_instance.map_directory('/tmp/host')
+        tmp = dict()
+        tmp['/tmp/host'] = dict()
+        tmp['/tmp/host']['bind'] = '/tmp/host'
+        tmp['/tmp/host']['mode'] = 'rw'
+        self.assertEqual(docker_instance.directory_map, tmp)
+
+    def test_add_bash_command(self):
+        docker_instance = self.get_image()
+        tmp = list()
+        tmp.append("echo 'hello, world!'")
+        docker_instance.add_bash_command("echo 'hello, world!'")
+        self.assertEqual(docker_instance.bash_cmds, tmp)

--- a/tests/test_docker.py
+++ b/tests/test_docker.py
@@ -1,0 +1,31 @@
+# Copyright 2018 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from time import gmtime, strftime
+import re
+
+from superflore.docker import docker
+class TestDocker(unittest.TestCase):
+    def get_image(self):
+        docker_file = resource_filename('repoman_docker', 'Dockerfile')
+        dock = Docker(docker_file, 'gentoo_repoman')
+        return dock
+
+    def test_init(self):
+        docker_instance = get_image()
+        self.assertTrue(docker_instance.client)
+        self.assertEqual(docker_instance.name, 'gentoo_repoman')
+        self.assertEqual(docker_instance.image, None)
+        self.assertEqual(docker_instance.directory_map, dict())
+


### PR DESCRIPTION
This adds some test coverage for the docker file. The uncovered sections of the code are the `build` and `run` functions, which both depend on the docker command.

```
allenh1@hunter-laptop ~/work/superflore $ coverage run --source=superflore -m "nose" && coverage report -m 
.............................
----------------------------------------------------------------------
Ran 29 tests in 1.892s

OK
Name                                               Stmts   Miss  Cover   Missing
--------------------------------------------------------------------------------
superflore/CacheManager.py                            20     13    35%   23-24, 28-33, 37-41
superflore/TempfileManager.py                         34     23    32%   27-28, 31-41, 44-57
superflore/__init__.py                                10      4    60%   5-8
superflore/docker.py                                  32     12    62%   40, 43-59
superflore/exceptions.py                              12      3    75%   18, 28, 33
superflore/generate_installers.py                     57     48    16%   32-86
superflore/generators/__init__.py                      0      0   100%
superflore/generators/bitbake/__init__.py              3      1    67%   3
superflore/generators/bitbake/gen_packages.py        115     92    20%   40-103, 110-166, 174-182, 188
superflore/generators/bitbake/ros_meta.py             27     18    33%   24-27, 30-35, 38-51, 54-55
superflore/generators/bitbake/run.py                 113     94    17%   39-44, 51-199
superflore/generators/bitbake/yocto_recipe.py        112     92    18%   43-64, 67, 70-74, 77-89, 92-96, 99-101, 104-105, 113-116, 125-177
superflore/generators/ebuild/__init__.py               3      1    67%   3
superflore/generators/ebuild/ebuild.py               135      7    95%   125-127, 131-136
superflore/generators/ebuild/gen_packages.py         151    125    17%   45-113, 118-150, 155-211, 216-233, 236, 239
superflore/generators/ebuild/metadata_xml.py          33     30     9%   18-24, 27-49
superflore/generators/ebuild/overlay_instance.py      37     25    32%   27-32, 35-45, 48-64, 67-68
superflore/generators/ebuild/run.py                  157    137    13%   40-43, 47-52, 59-250
superflore/repo_instance.py                           49     34    31%   26-35, 38-46, 49-57, 63, 69, 75, 81, 84-91
superflore/rosdep_support.py                          34      2    94%   83-84
superflore/utils.py                                  126     53    58%   28, 32, 36, 40, 44-50, 54-59, 66, 104, 108, 114, 119, 121-124, 126, 132, 138-139, 144, 148-149, 156-177
--------------------------------------------------------------------------------
TOTAL                                               1260    814    35%
```