### PR TITLE
More utils tests

### DIFF
--- a/superflore/utils.py
+++ b/superflore/utils.py
@@ -24,19 +24,19 @@ from superflore.rosdep_support import resolve_rosdep_key
 from termcolor import colored
 
 
-def warn(string):
+def warn(string):  # pragma: no cover
     print(colored('>>>> {0}'.format(string), 'yellow'))
 
 
-def ok(string):
+def ok(string):  # pragma: no cover
     print(colored('>>>> {0}'.format(string), 'green'))
 
 
-def err(string):
+def err(string):  # pragma: no cover
     print(colored('!!!! {0}'.format(string), 'red'))
 
 
-def info(string):
+def info(string):  # pragma: no cover
     print(colored('>>>> {0}'.format(string), 'cyan'))
 
 

--- a/superflore/utils.py
+++ b/superflore/utils.py
@@ -59,7 +59,7 @@ def get_pkg_version(distro, pkg_name):
     return maj_min_patch
 
 
-def rand_ascii_str(length=10):  # pragma: no cover
+def rand_ascii_str(length=10):
     """
     Generates a random string of ascii characters of length 'length'
     """

--- a/superflore/utils.py
+++ b/superflore/utils.py
@@ -40,7 +40,7 @@ def info(string):  # pragma: no cover
     print(colored('>>>> {0}'.format(string), 'cyan'))
 
 
-def make_dir(dirname):
+def make_dir(dirname):  # pragma: no cover
     try:
         os.makedirs(dirname)
     except OSError as e:
@@ -59,7 +59,7 @@ def get_pkg_version(distro, pkg_name):
     return maj_min_patch
 
 
-def rand_ascii_str(length=10):
+def rand_ascii_str(length=10):  # pragma: no cover
     """
     Generates a random string of ascii characters of length 'length'
     """

--- a/superflore/utils.py
+++ b/superflore/utils.py
@@ -40,7 +40,7 @@ def info(string):  # pragma: no cover
     print(colored('>>>> {0}'.format(string), 'cyan'))
 
 
-def make_dir(dirname):  # pragma: no cover
+def make_dir(dirname):
     try:
         os.makedirs(dirname)
     except OSError as e:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -52,6 +52,8 @@ class TestUtils(unittest.TestCase):
         self.assertEqual(ret, 'Apache-2.0')
         ret = get_license('Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)')
         self.assertEqual(ret, 'Apache-2.0')
+        ret = get_license('Apache')
+        self.assertEqual(ret, 'Apache-1.0')
         ret = get_license('BSD-3')
         self.assertEqual(ret, 'BSD')
         ret = get_license('Apache-2')
@@ -66,6 +68,5 @@ class TestUtils(unittest.TestCase):
         self.assertEqual(ret, 'GPL-3')
         ret = get_license('Public Domain')
         self.assertEqual(ret, 'public_domain')
-
-if __name__ == '__main__':
-    unittest.main()
+        ret = get_license('GPL')
+        self.assertEqual(ret, 'GPL-1')

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -12,10 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from superflore.utils import make_dir
 from superflore.utils import sanitize_string
 from superflore.utils import trim_string
 from superflore.utils import get_license
+from superflore.TempfileManager import TempfileManager
 
+import os
 import unittest
 
 
@@ -43,6 +46,16 @@ class TestUtils(unittest.TestCase):
         # test mixed case
         ret = trim_string('abcdef', length=6)
         self.assertEqual(ret, 'a[...]')
+
+    def test_mkdir(self):
+        """Tests the make directory funciton"""
+        with TempfileManager(None) as temp_dir:
+            created = '%s/test' % temp_dir
+            make_dir(created)
+            self.assertTrue(os.path.isdir(created))
+            # try and create the directory again, should pass
+            make_dir(created)
+            self.assertTrue(os.path.isdir(created))
 
     def test_get_license(self):
         """Test license recognition function"""

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -13,12 +13,14 @@
 # limitations under the License.
 
 from superflore.utils import make_dir
+from superflore.utils import rand_ascii_str
 from superflore.utils import sanitize_string
 from superflore.utils import trim_string
 from superflore.utils import get_license
 from superflore.TempfileManager import TempfileManager
 
 import os
+import string
 import unittest
 
 
@@ -56,6 +58,12 @@ class TestUtils(unittest.TestCase):
             # try and create the directory again, should pass
             make_dir(created)
             self.assertTrue(os.path.isdir(created))
+
+    def test_rand_ascii_str(self):
+        """Test the random ascii generation function"""
+        rand = rand_ascii_str(100)
+        self.assertEqual(len(rand), 100)
+        self.assertTrue(all(c in string.ascii_letters for c in rand))
 
     def test_get_license(self):
         """Test license recognition function"""


### PR DESCRIPTION
Mark certain functions with `# pragma: no cover` so that they don't get counted in the coverage results, as well as add a bit more to the license tests.

```
allenh1@hunter-laptop ~/work/superflore $ coverage run --source=superflore -m "nose" && coverage report -m
..............................
----------------------------------------------------------------------
Ran 30 tests in 1.879s

OK
Name                                               Stmts   Miss  Cover   Missing
--------------------------------------------------------------------------------
superflore/CacheManager.py                            20     13    35%   23-24, 28-33, 37-41
superflore/TempfileManager.py                         34     23    32%   27-28, 31-41, 44-57
superflore/__init__.py                                10      4    60%   5-8
superflore/docker.py                                  32     12    62%   40, 43-59
superflore/exceptions.py                              12      3    75%   18, 28, 33
superflore/generate_installers.py                     57     48    16%   32-86
superflore/generators/__init__.py                      0      0   100%
superflore/generators/bitbake/__init__.py              3      1    67%   3
superflore/generators/bitbake/gen_packages.py        115     92    20%   40-103, 110-166, 174-182, 188
superflore/generators/bitbake/ros_meta.py             27     18    33%   24-27, 30-35, 38-51, 54-55
superflore/generators/bitbake/run.py                 113     94    17%   39-44, 51-199
superflore/generators/bitbake/yocto_recipe.py        112     92    18%   43-64, 67, 70-74, 77-89, 92-96, 99-101, 104-105, 113-116, 125-177
superflore/generators/ebuild/__init__.py               3      1    67%   3
superflore/generators/ebuild/ebuild.py               135      7    95%   125-127, 131-136
superflore/generators/ebuild/gen_packages.py         151    125    17%   45-113, 118-150, 155-211, 216-233, 236, 239
superflore/generators/ebuild/metadata_xml.py          33      0   100%
superflore/generators/ebuild/overlay_instance.py      37     25    32%   27-32, 35-45, 48-64, 67-68
superflore/generators/ebuild/run.py                  157    137    13%   40-43, 47-52, 59-250
superflore/repo_instance.py                           49     34    31%   26-35, 38-46, 49-57, 63, 69, 75, 81, 84-91
superflore/rosdep_support.py                          34      2    94%   83-84
superflore/utils.py                                  109     40    63%   54-59, 108, 114, 121-124, 126, 132, 138-139, 144, 148-149, 156-177
--------------------------------------------------------------------------------
TOTAL                                               1243    771    38%
```