### PR TITLE
Added tests for generate_installers function.

### DIFF
--- a/tests/test_generate_installers.py
+++ b/tests/test_generate_installers.py
@@ -1,0 +1,109 @@
+# Copyright 2018 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from superflore.exceptions import UnknownBuildType
+from superflore.exceptions import UnknownLicense
+from superflore.generate_installers import generate_installers
+import unittest
+
+
+def _gen_package(overlay, pkg, distro, preserve_existing, collector):
+    """This is just a stub. We just add to the collector"""
+    collector.append(pkg)
+    # return new installer, name it.
+    return True, pkg
+
+
+def _fail_if_p2os(overlay, pkg, distro, preserve_existing, collector):
+    """Fail if it's a p2os package"""
+    collector.append(pkg)
+    if 'p2os' in pkg:
+        return False, pkg
+    return True, pkg
+
+
+def _skip_if_p2os(overlay, pkg, distro, preserve_existing, collector):
+    """Skip if it's a p2os package"""
+    collector.append(pkg)
+    if 'p2os' in pkg:
+        return False, False
+    return True, pkg
+
+
+def _raise_exceptions(overlay, pkg, distro, preserve_existing, collector):
+    """Raise exceptions"""
+    collector.append(pkg)
+    if 'l' in pkg:
+        raise UnknownLicense('l')
+    elif 'b' in pkg:
+        raise UnknownBuildType('b')
+    elif 'k' in pkg:
+        raise KeyError('k')
+    return True, pkg
+
+
+class TestGenerateInstallers(unittest.TestCase):
+    def test_generation(self):
+        """Test Generate Installers"""
+        acc = list()
+        # attempt to generate the installers
+        inst, broken, changes = generate_installers(
+            'lunar', None, _gen_package, False, acc
+        )
+        # since we don't do anything, there should be no failures.
+        self.assertEqual(broken,{})
+        # make sure all packages got indexed
+        self.assertEqual(sorted(acc), sorted(inst))
+
+    def test_unresolved(self):
+        """Test for an unresolved dependency"""
+        acc = list()
+        inst, broken, changes = generate_installers(
+            'lunar', None, _fail_if_p2os, False, acc
+        )
+        broken = [b for b in broken]
+        total_list = inst + broken
+        # total list should have all packages in acc
+        self.assertEqual(sorted(total_list), sorted(acc))
+        # find missing packages, generate the change
+        missing = [p for p in acc if not p in inst]
+        # compare the contents
+        self.assertEqual(sorted(broken), sorted(missing))
+
+    def test_skipped(self):
+        """Test how skipped packages are handled"""
+        acc = list()
+        inst, broken, changes = generate_installers(
+            'lunar', None, _skip_if_p2os, True, acc
+        )
+        broken = [b for b in broken]
+        total_list = inst + broken
+        # total list should have less than acc
+        self.assertNotEqual(sorted(total_list), sorted(broken))
+        missing = [p for p in acc if not p in total_list]
+        # should only have 'p2os' packages
+        non_p2os = [p for p in missing if 'p2os' not in p]
+        self.assertEqual(non_p2os, [])
+
+    def test_exceptions(self):
+        """Test exceptions"""
+        acc = list()
+        inst, broken, changes = generate_installers(
+            'lunar', None, _raise_exceptions, True, acc
+        )
+        # anything with a 'k', 'l', or a 'b' has been skipped
+        for p in inst:
+            self.assertNotIn('k', p)
+            self.assertNotIn('l', p)
+            self.assertNotIn('b', p)


### PR DESCRIPTION
This is the coverage with these changes.

```
$ coverage run --source=superflore -m nose && coverage report -m
...........................................
----------------------------------------------------------------------
Ran 43 tests in 11.640s

OK
Name                                               Stmts   Miss  Cover   Missing
--------------------------------------------------------------------------------
superflore/CacheManager.py                            20     13    35%   23-24, 28-33, 37-41
superflore/PackageMetadata.py                         22     18    18%   22-50
superflore/TempfileManager.py                         34     12    65%   32-37, 48-56
superflore/__init__.py                                10      4    60%   5-8
superflore/docker.py                                  51     12    76%   40, 54-67, 77, 80-81
superflore/exceptions.py                              18      3    83%   28, 33, 38
superflore/generate_installers.py                     63      1    98%   73
superflore/generators/__init__.py                      0      0   100%
superflore/generators/bitbake/__init__.py              3      1    67%   3
superflore/generators/bitbake/gen_packages.py        102     79    23%   40-122, 129-168, 175-183, 189
superflore/generators/bitbake/ros_meta.py             27     18    33%   24-27, 30-35, 38-51, 54-55
superflore/generators/bitbake/run.py                 113     90    20%   43-187
superflore/generators/bitbake/yocto_recipe.py        120    100    17%   44-67, 70, 73-77, 80-92, 95-99, 102-104, 107-108, 116-119, 128-187
superflore/generators/ebuild/__init__.py               3      1    67%   3
superflore/generators/ebuild/ebuild.py               185     19    90%   96-99, 126-131, 146, 176-180, 186, 193, 206-210
superflore/generators/ebuild/gen_packages.py         140    113    19%   46-119, 125-137, 143-188, 193-210, 213, 216
superflore/generators/ebuild/metadata_xml.py          33      0   100%
superflore/generators/ebuild/overlay_instance.py      35     24    31%   26-31, 34-45, 50-69, 72-73
superflore/generators/ebuild/run.py                  121     95    21%   48-188, 192-196
superflore/parser.py                                  13     11    15%   20-62
superflore/repo_instance.py                           70     51    27%   29-49, 56-65, 68-76, 82-83, 89, 95-96, 102, 105-120, 123
superflore/rosdep_support.py                          34      2    94%   83-84
superflore/test_integration/__init__.py                0      0   100%
superflore/test_integration/gentoo/__init__.py         3      1    67%   3
superflore/test_integration/gentoo/build_base.py      26     17    35%   26-28, 33, 38-50
superflore/test_integration/gentoo/main.py            30     24    20%   26-71
superflore/utils.py                                  189     67    65%   50-56, 60-63, 67-82, 86-97, 101-104, 114, 174, 191-194, 196, 202, 208-209, 214, 218-219, 226-247
--------------------------------------------------------------------------------
TOTAL                                               1465    776    47%
```