### PR TITLE
Remove compiler optimization flags for RViz.

### DIFF
--- a/superflore/generators/ebuild/ebuild.py
+++ b/superflore/generators/ebuild/ebuild.py
@@ -32,6 +32,7 @@ no_optimizations = [
     'rviz',
 ]
 
+
 class ebuild_keyword(object):
     def __init__(self, arch, stable):
         self.arch = arch

--- a/superflore/generators/ebuild/ebuild.py
+++ b/superflore/generators/ebuild/ebuild.py
@@ -28,6 +28,9 @@ depend_only_pkgs = [
     'virtual/pkgconfig'
 ]
 
+no_optimizations = [
+    'rviz',
+]
 
 class ebuild_keyword(object):
     def __init__(self, arch, stable):
@@ -259,7 +262,13 @@ class Ebuild(object):
             ret += "    filter-flags '-std=*'\n"
             ret += "    ros-cmake_src_configure\n"
             ret += "}\n"
-
+        elif self.name in no_optimizations:
+            ret += "\nsrc_configure() {\n"
+            ret += "    filter-flags '-O*'\n"
+            ret += "    append-cflags '-O0'\n"
+            ret += "    append-cxxflags '-O0'\n"
+            ret += "    ros-cmake_src_configure\n"
+            ret += "}\n"
         if len(self.unresolved_deps) > 0:
             raise UnresolvedDependency("failed to satisfy dependencies!")
 


### PR DESCRIPTION
RViz currently crashes on Gentoo if it's not compiled with "-O0", so this removes optimizations for Rviz (and leaves other packages as a possibility) on Gentoo.
