### PR TITLE
Add tests for PackageMetadata.py.

### DIFF
--- a/tests/PackageXml/test.xml
+++ b/tests/PackageXml/test.xml
@@ -1,0 +1,38 @@
+<package format="2">
+  <name>my_package</name>
+  <version>1.2.3</version>
+  <description>
+    This is my package's description.
+  </description>
+  <maintainer email="someone@example.com">Someone</maintainer>
+
+  <license>BSD</license>
+  <license>LGPL</license>
+
+  <url type="website">http://wiki.ros.org/my_package</url>
+  <url type="repository">http://www.github.com/my_org/my_package</url>
+  <url type="bugtracker">http://www.github.com/my_org/my_package/issues</url>
+  <author>John Doe</author>
+  <author email="jane.doe@example.com">Jane Doe</author>
+
+  <buildtool_depend>catkin</buildtool_depend>
+  <build_depend version_gte="1.1" version_lt="2.0">genmsg</build_depend>
+
+  <depend>roscpp</depend>
+
+  <build_depend>libgstreamer0.10-dev</build_depend>
+  <build_export_depend>libgstreamer0.10-dev</build_export_depend>
+  <exec_depend>libgstreamer0.10-0</exec_depend>
+
+  <test_depend>gtest</test_depend>
+
+  <doc_depend>doxygen</doc_depend>
+
+  <conflict>alternative_implementation</conflict>
+
+  <replace>my_old_package</replace>
+
+  <export>
+    <build_type>my_builder</build_type>
+  </export>
+</package>

--- a/tests/PackageXml/test2.xml
+++ b/tests/PackageXml/test2.xml
@@ -1,0 +1,38 @@
+<package format="2">
+  <name>my_package</name>
+  <version>1.2.3</version>
+  <description>
+    This is my package's description.
+  </description>
+  <maintainer email="someone@example.com">Someone</maintainer>
+
+  <license>BSD</license>
+  <license>LGPL</license>
+
+  <url type="repository">http://www.github.com/my_org/my_package</url>
+  <url type="bugtracker">http://www.github.com/my_org/my_package/issues</url>
+
+  <author>John Doe</author>
+  <author email="jane.doe@example.com">Jane Doe</author>
+
+  <buildtool_depend>catkin</buildtool_depend>
+  <build_depend version_gte="1.1" version_lt="2.0">genmsg</build_depend>
+
+  <depend>roscpp</depend>
+
+  <build_depend>libgstreamer0.10-dev</build_depend>
+  <build_export_depend>libgstreamer0.10-dev</build_export_depend>
+  <exec_depend>libgstreamer0.10-0</exec_depend>
+
+  <test_depend>gtest</test_depend>
+
+  <doc_depend>doxygen</doc_depend>
+
+  <conflict>alternative_implementation</conflict>
+
+  <replace>my_old_package</replace>
+
+  <export>
+    <build_type>my_builder</build_type>
+  </export>
+</package>

--- a/tests/test_PackageMetadata.py
+++ b/tests/test_PackageMetadata.py
@@ -1,0 +1,37 @@
+# Copyright 2018 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from superflore.PackageMetadata import PackageMetadata
+import unittest
+
+
+class TestPackageMetadata(unittest.TestCase):
+    def test_metadata(self):
+        """Test the Package Metadata parsing"""
+        with open('tests/PackageXml/test.xml', 'r') as test_file:
+            test_xml = test_file.read()
+        ret = PackageMetadata(test_xml)
+        self.assertEqual(ret.upstream_email, 'someone@example.com')
+        self.assertEqual(ret.upstream_name, 'Someone')
+        self.assertEqual(ret.description, 'This is my package\'s description.')
+        self.assertEqual(ret.longdescription, 'This is my package\'s description.')
+        self.assertEqual(ret.homepage, 'http://wiki.ros.org/my_package')
+        self.assertEqual(ret.build_type, 'my_builder')
+
+    def test_no_homepage(self):
+        """Test Package Metadata parsing without a homepage field"""
+        with open('tests/PackageXml/test2.xml', 'r') as test_file:
+            test_xml = test_file.read()
+        ret = PackageMetadata(test_xml)
+        self.assertEqual(ret.homepage, 'http://www.github.com/my_org/my_package')


### PR DESCRIPTION
Adds tests for the `PackageMetadata.py` file brought in by #134.

```
$ coverage run --source=superflore -m nose && coverage report -m
..............................................
----------------------------------------------------------------------
Ran 46 tests in 12.760s

OK
Name                                               Stmts   Miss  Cover   Missing
--------------------------------------------------------------------------------
superflore/CacheManager.py                            20     13    35%   23-24, 28-33, 37-41
superflore/PackageMetadata.py                         22      0   100%
superflore/TempfileManager.py                         34     12    65%   32-37, 48-56
superflore/__init__.py                                10      4    60%   5-8
superflore/docker.py                                  51     12    76%   40, 54-67, 77, 80-81
superflore/exceptions.py                              18      3    83%   28, 33, 38
superflore/generate_installers.py                     63      0   100%
superflore/generators/__init__.py                      0      0   100%
superflore/generators/bitbake/__init__.py              3      1    67%   3
superflore/generators/bitbake/gen_packages.py        102     79    23%   40-122, 129-168, 175-183, 189
superflore/generators/bitbake/ros_meta.py             27     18    33%   24-27, 30-35, 38-51, 54-55
superflore/generators/bitbake/run.py                 113     90    20%   43-187
superflore/generators/bitbake/yocto_recipe.py        120    100    17%   44-67, 70, 73-77, 80-92, 95-99, 102-104, 107-108, 116-119, 128-187
superflore/generators/ebuild/__init__.py               3      1    67%   3
superflore/generators/ebuild/ebuild.py               185     19    90%   96-99, 126-131, 146, 176-180, 186, 193, 206-210
superflore/generators/ebuild/gen_packages.py         140    113    19%   46-119, 125-137, 143-188, 193-210, 213, 216
superflore/generators/ebuild/metadata_xml.py          33      0   100%
superflore/generators/ebuild/overlay_instance.py      35     24    31%   26-31, 34-45, 50-69, 72-73
superflore/generators/ebuild/run.py                  121     95    21%   48-188, 192-196
superflore/parser.py                                  13     11    15%   20-62
superflore/repo_instance.py                           70     51    27%   29-49, 56-65, 68-76, 82-83, 89, 95-96, 102, 105-120, 123
superflore/rosdep_support.py                          34      2    94%   83-84
superflore/test_integration/__init__.py                0      0   100%
superflore/test_integration/gentoo/__init__.py         3      1    67%   3
superflore/test_integration/gentoo/build_base.py      26     17    35%   26-28, 33, 38-50
superflore/test_integration/gentoo/main.py            30     24    20%   26-71
superflore/utils.py                                  189     67    65%   50-56, 60-63, 67-82, 86-97, 101-104, 114, 174, 191-194, 196, 202, 208-209, 214, 218-219, 226-247
--------------------------------------------------------------------------------
TOTAL                                               1465    757    48%
```