### PR TITLE
Create a way to get the log from the docker container.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ before_install:
   - sudo apt-get update -qq
   - sudo apt-get install -y python-rosdep
   - sudo gpasswd -a $USER docker
+  - mkdir -p ~/.docker && touch ~/.docker/config.json
 # command to install dependencies
 install:
   - pip install -r requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,11 +12,6 @@ before_install:
   - sudo apt-key adv --keyserver hkp://ha.pool.sks-keyservers.net:80 --recv-key 421C365BD9FF1F717815A3895523BAEEB01FA116
   - sudo apt-get update -qq
   - sudo apt-get install -y python-rosdep
-  - sudo gpasswd -a $USER docker
-  - mkdir -p ~/.docker && touch ~/.docker/config.json
-  - echo "{" > ~/.docker/config.json
-  - echo "}" >> ~/.docker/config.json
-
 # command to install dependencies
 install:
   - pip install -r requirements.txt
@@ -24,5 +19,5 @@ install:
 script:
   - sudo rosdep init
   - rosdep update
-  - python -m 'nose' --exclude test_pull --exclude test_run
+  - python -m 'nose' --exclude test_pull --exclude test_run --exclude test_logger_output
   - python -m 'flake8' superflore --import-order-style=google

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ before_install:
   - sudo apt-key adv --keyserver hkp://ha.pool.sks-keyservers.net:80 --recv-key 421C365BD9FF1F717815A3895523BAEEB01FA116
   - sudo apt-get update -qq
   - sudo apt-get install -y python-rosdep
-  - groupadd $USER docker
+  - sudo gpasswd -a $USER docker
 # command to install dependencies
 install:
   - pip install -r requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ before_install:
   - sudo apt-key adv --keyserver hkp://ha.pool.sks-keyservers.net:80 --recv-key 421C365BD9FF1F717815A3895523BAEEB01FA116
   - sudo apt-get update -qq
   - sudo apt-get install -y python-rosdep
+  - groupadd $USER docker
 # command to install dependencies
 install:
   - pip install -r requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,9 @@ before_install:
   - sudo apt-get install -y python-rosdep
   - sudo gpasswd -a $USER docker
   - mkdir -p ~/.docker && touch ~/.docker/config.json
+  - echo "{" > ~/.docker/config.json
+  - echo "}" >> ~/.docker/config.json
+
 # command to install dependencies
 install:
   - pip install -r requirements.txt

--- a/README.md
+++ b/README.md
@@ -60,7 +60,8 @@ $ superflore-check-ebuilds -h
 usage: Check if ROS packages are building for Gentoo Linux [-h]
                                                            [--ros-distro ROS_DISTRO [ROS_DISTRO ...]]
                                                            [--pkgs PKGS [PKGS ...]]
-                                                           [-f F]
+                                                           [-f F] [-v]
+                                                           [--log-file LOG_FILE]
 
 optional arguments:
   -h, --help            show this help message and exit
@@ -69,6 +70,8 @@ optional arguments:
   --pkgs PKGS [PKGS ...]
                         packages to build
   -f F                  build packages specified by the input file
+  -v, --verbose         show output from docker
+  --log-file LOG_FILE   location to store the log file
 ```
 
 If a file is to be passed as input, it is expected to be in proper yaml format, such as the below.

--- a/superflore/docker.py
+++ b/superflore/docker.py
@@ -102,7 +102,7 @@ class Docker(object):
                 os.chmod(tmp, 17407)
             # map into the container
             self.map_directory(tmp)
-            cmd_string = self.get_command(tmp)
+            cmd_string = self.get_command(tmp, log_name)
             if show_cmd:
                 msg = "Running container with command string '%s'..."
                 info(msg % self.get_command())

--- a/superflore/docker.py
+++ b/superflore/docker.py
@@ -92,12 +92,11 @@ class Docker(object):
             # get the location to store the log
             log_path = os.path.dirname(log_file)
             # get the file name
-            log_name = log_file.replace(log_path, '')
+            log_name = log_file.replace(log_path, '').lstrip('/')
         else:
             log_path = None
             log_name = 'log.txt'
         with TempfileManager(log_path) as tmp:
-            tmp = tmp.rstrip('/')
             if log_file:
                 # change access to the directory so docker can read it
                 os.chmod(tmp, 17407)

--- a/superflore/docker.py
+++ b/superflore/docker.py
@@ -111,6 +111,7 @@ class Docker(object):
             with open('%s/log.txt' % tmp, 'r') as logfile:
                 self.log = logfile.read()
 
+
 class NoDockerfileSupplied(Exception):
     def __init__(self, message):
         self.message = message

--- a/superflore/docker.py
+++ b/superflore/docker.py
@@ -106,7 +106,7 @@ class Docker(object):
             cmd_string = self.get_command(tmp, log_name)
             if show_cmd:
                 msg = "Running container with command string '%s'..."
-                info(msg % self.get_command())
+                info(msg % cmd_string)
             try:
                 self.client.containers.run(
                     image=self.image,

--- a/superflore/docker.py
+++ b/superflore/docker.py
@@ -97,6 +97,7 @@ class Docker(object):
             log_path = None
             log_name = 'log.txt'
         with TempfileManager(log_path) as tmp:
+            tmp = tmp.rstrip('/')
             if log_file:
                 # change access to the directory so docker can read it
                 os.chmod(tmp, 17407)

--- a/superflore/docker.py
+++ b/superflore/docker.py
@@ -80,7 +80,7 @@ class Docker(object):
             cmd += (" &>> %s/log.txt && " % logging_dir).join(self.bash_cmds)
             cmd += (" &>> %s/log.txt'" % logging_dir)
         else:
-            cmd = "bash -c '" + " && ".join(self.bash_cmds)
+            cmd = "bash -c '" + " && ".join(self.bash_cmds) + "'"
         return cmd
 
     def run(self, rm=True, show_cmd=False, privileged=False):

--- a/superflore/test_integration/gentoo/build_base.py
+++ b/superflore/test_integration/gentoo/build_base.py
@@ -32,7 +32,7 @@ class GentooBuilder:
         # in case we want to test both.
         self.package_list['ros-%s/%s' % (ros_distro, pkg)] = 'unknown'
 
-    def run(self, verbose=True):
+    def run(self, verbose=True, log_file=None):
         # TODO(allenh1): add the ability to check out a non-master
         # branch of the overlay (for CI).
         info('testing gentoo package integrity')
@@ -40,7 +40,9 @@ class GentooBuilder:
             self.container.add_bash_command('emaint sync -r ros-overlay')
             self.container.add_bash_command('emerge %s' % pkg)
             try:
-                self.container.run(rm=True, show_cmd=True, privileged=True)
+                self.container.run(
+                    rm=True, show_cmd=True, privileged=True, log_file=log_file
+                )
                 self.package_list[pkg] = 'building'
                 ok("  '%s': building" % pkg)
             except ContainerError:

--- a/superflore/test_integration/gentoo/build_base.py
+++ b/superflore/test_integration/gentoo/build_base.py
@@ -32,7 +32,7 @@ class GentooBuilder:
         # in case we want to test both.
         self.package_list['ros-%s/%s' % (ros_distro, pkg)] = 'unknown'
 
-    def run(self):
+    def run(self, verbose=True):
         # TODO(allenh1): add the ability to check out a non-master
         # branch of the overlay (for CI).
         info('testing gentoo package integrity')
@@ -46,5 +46,7 @@ class GentooBuilder:
             except ContainerError:
                 self.package_list[pkg] = 'failing'
                 err("  '%s': failing" % pkg)
+            if verbose:
+                print(self.container.log)
             self.container.clear_commands()
         return self.package_list

--- a/superflore/test_integration/gentoo/main.py
+++ b/superflore/test_integration/gentoo/main.py
@@ -49,6 +49,11 @@ def main():
         help='show output from docker',
         action="store_true"
     )
+    parser.add_argument(
+        '--log-file',
+        help='location to store the log file',
+        type='str'
+    )
     args = parser.parse_args(sys.argv[1:])
 
     if args.f:
@@ -66,7 +71,7 @@ def main():
     else:
         parser.error('Invalid args! You must supply a package list.')
         sys.exit(1)
-    results = tester.run(args.verbose)
+    results = tester.run(args.verbose, args.log_file)
     failures = 0
     for test_case in results.keys():
         if results[test_case] == 'failing':

--- a/superflore/test_integration/gentoo/main.py
+++ b/superflore/test_integration/gentoo/main.py
@@ -15,8 +15,8 @@
 import argparse
 import sys
 
-from superflore.utils import active_distros
 from superflore.test_integration.gentoo.build_base import GentooBuilder
+from superflore.utils import active_distros
 import yaml
 
 

--- a/superflore/test_integration/gentoo/main.py
+++ b/superflore/test_integration/gentoo/main.py
@@ -52,7 +52,7 @@ def main():
     parser.add_argument(
         '--log-file',
         help='location to store the log file',
-        type='str'
+        type=str
     )
     args = parser.parse_args(sys.argv[1:])
 

--- a/superflore/test_integration/gentoo/main.py
+++ b/superflore/test_integration/gentoo/main.py
@@ -45,6 +45,12 @@ def main():
         help='build packages specified by the input file',
         type=str
     )
+    parser.add_argument(
+        '-v',
+        '--verbose',
+        help='show output from docker',
+        action="store_true"
+    )
     args = parser.parse_args(sys.argv[1:])
 
     if args.f:
@@ -62,7 +68,7 @@ def main():
     else:
         parser.error('Invalid args! You must supply a package list.')
         sys.exit(1)
-    results = tester.run()
+    results = tester.run(args.verbose)
     failures = 0
     for test_case in results.keys():
         if results[test_case] == 'failing':

--- a/superflore/test_integration/gentoo/main.py
+++ b/superflore/test_integration/gentoo/main.py
@@ -15,11 +15,9 @@
 import argparse
 import sys
 
+from superflore.utils import active_distros
 from superflore.test_integration.gentoo.build_base import GentooBuilder
 import yaml
-
-
-active_distros = ['indigo', 'kinetic', 'lunar']
 
 
 def main():

--- a/tests/test_docker.py
+++ b/tests/test_docker.py
@@ -87,6 +87,7 @@ class TestDocker(unittest.TestCase):
     def test_logger_output(self):
         """Test the log file output"""
         docker_instance = Docker()
+        docker_instance.pull('allenh1', 'ros_gentoo_base')
         docker_instance.add_bash_command("echo Log Text!")
         docker_instance.run()
         self.assertEqual(docker_instance.log, "Log Text!")

--- a/tests/test_docker.py
+++ b/tests/test_docker.py
@@ -83,3 +83,10 @@ class TestDocker(unittest.TestCase):
         expected = "bash -c 'echo Hello, docker &>> /root/log.txt "\
                    "&& echo command two. &>> /root/log.txt'"
         self.assertEqual(expected, ret)
+
+    def test_logger_output(self):
+        """Test the log file output"""
+        docker_instance = Docker()
+        docker_instance.add_bash_command("echo Log Text!")
+        docker_instance.run()
+        self.assertEqual(docker_instance.log, "Log Text!")

--- a/tests/test_docker.py
+++ b/tests/test_docker.py
@@ -87,7 +87,7 @@ class TestDocker(unittest.TestCase):
     def test_logger_output(self):
         """Test the log file output"""
         docker_instance = Docker()
-        docker_instance.pull('allenh1', 'ros_gentoo_base')
+        docker_instance.pull('gentoo', 'stage3-amd64')
         docker_instance.add_bash_command("echo Log Text!")
         docker_instance.run()
-        self.assertEqual(docker_instance.log, "Log Text!")
+        self.assertEqual(docker_instance.log, "Log Text!\n")

--- a/tests/test_docker.py
+++ b/tests/test_docker.py
@@ -79,7 +79,7 @@ class TestDocker(unittest.TestCase):
         ret = docker_instance.get_command()
         self.assertEqual(ret, "bash -c 'echo Hello, docker && echo command two.'")
         # get command string with logging directory.
-        ret = docker_instance.get_command('/root')
+        ret = docker_instance.get_command('/root', 'log.txt')
         expected = "bash -c 'echo Hello, docker &>> /root/log.txt "\
                    "&& echo command two. &>> /root/log.txt'"
         self.assertEqual(expected, ret)

--- a/tests/test_docker.py
+++ b/tests/test_docker.py
@@ -69,3 +69,17 @@ class TestDocker(unittest.TestCase):
         docker_instance.pull('allenh1', 'ros_gentoo_base')
         docker_instance.add_bash_command("echo Hello, Gentoo")
         docker_instance.run()
+
+    def test_get_command(self):
+        """Test the get_comamnd function"""
+        docker_instance = Docker()
+        docker_instance.add_bash_command("echo Hello, docker")
+        docker_instance.add_bash_command("echo command two.")
+        # get command string
+        ret = docker_instance.get_command()
+        self.assertEqual(ret, "bash -c 'echo Hello, docker && echo command two.'")
+        # get command string with logging directory.
+        ret = docker_instance.get_command('/root')
+        expected = "bash -c 'echo Hello, docker &>> /root/log.txt "\
+                   "&& echo command two. &>> /root/log.txt'"
+        self.assertEqual(expected, ret)


### PR DESCRIPTION
This creates a logger mechanism for the docker container. We create a temporary directory using `TempfileManager`, then send the `stderr`and `stdout` streams into the file in append mode.

This allows us to grab the output even when commands return an error code, which is more desirable than just grabbing the output of successful commands (imo).

ToDo: parameterize the verbosity, add tests.

connects to #146 