### PR TITLE
Even more utils tests

### DIFF
--- a/superflore/utils.py
+++ b/superflore/utils.py
@@ -50,10 +50,12 @@ def get_pr_text(comment=None):
     msg = ''
     if comment:
         msg += '%s\n' % comment
+        return msg
     msg += 'To reproduce this PR, run the following command.\n\n'
     args = sys.argv
     args[0] = args[0].split('/')[-1]
-    msg += '```\n%s\n```' % ' '.join(args)
+    msg += '```\n%s\n```' % ' '.join(args) + '\n'
+    return msg
 
 
 def save_pr(overlay, delta, missing_deps, comment):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -16,6 +16,7 @@ import os
 import string
 import sys
 
+from superflore.exceptions import UnknownLicense
 from superflore.exceptions import UnknownPlatform
 from superflore.TempfileManager import TempfileManager
 from superflore.utils import clean_up
@@ -108,6 +109,18 @@ class TestUtils(unittest.TestCase):
         self.assertEqual(ret, 'GPL-3')
         ret = get_license('GNU Lesser Public License 2.1')
         self.assertEqual(ret, 'LGPL-2.1')
+        ret = get_license('Mozilla Public License Version 1.1')
+        self.assertEqual(ret, 'MPL-1.1')
+        ret = get_license('Mozilla Public License')
+        self.assertEqual(ret, 'MPL-2.0')
+        ret = get_license('BSD License 2.0')
+        self.assertEqual(ret, 'BSD-2')
+        ret = get_license('MIT')
+        self.assertEqual(ret, 'MIT')
+        ret = get_license('Creative Commons')
+        self.assertEqual(ret, 'CC-BY-SA-3.0')
+        with self.assertRaises(UnknownLicense):
+            ret = get_license('TODO')
 
     def test_delta_msg(self):
         """Test the delta message generated for the PR"""

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -18,6 +18,7 @@ import sys
 
 from superflore.exceptions import UnknownPlatform
 from superflore.TempfileManager import TempfileManager
+from superflore.utils import clean_up
 from superflore.utils import gen_delta_msg
 from superflore.utils import get_license
 from superflore.utils import gen_missing_deps_msg
@@ -163,3 +164,17 @@ class TestUtils(unittest.TestCase):
         # test with an argument
         expected = 'sample\n'
         self.assertEqual(expected, get_pr_text('sample'))
+
+    def test_cleanup(self):
+        # should pass
+        clean_up()
+        # should remove files
+        with TempfileManager(None) as tempdir:
+            with open('%s/.pr-message.tmp' % tempdir, 'w') as msg_file:
+                msg_file.write("message")
+            with open('%s/.pr-title.tmp' % tempdir, 'w') as title_file:
+                title_file.write("title")
+            os.chdir(tempdir)
+            clean_up()
+            self.assertFalse(os.path.exists('%s/.pr-message.tmp' % tempdir))
+            self.assertFalse(os.path.exists('%s/.pr-title.tmp' % tempdir))

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -12,20 +12,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
+import string
+import sys
+
 from superflore.exceptions import UnknownPlatform
+from superflore.TempfileManager import TempfileManager
+from superflore.utils import gen_delta_msg
+from superflore.utils import get_license
+from superflore.utils import gen_missing_deps_msg
+from superflore.utils import get_pr_text
 from superflore.utils import make_dir
 from superflore.utils import rand_ascii_str
 from superflore.utils import resolve_dep
 from superflore.utils import sanitize_string
 from superflore.utils import trim_string
-from superflore.utils import gen_delta_msg
-from superflore.utils import gen_missing_deps_msg
 from superflore.utils import url_to_repo_org
-from superflore.utils import get_license
-from superflore.TempfileManager import TempfileManager
 
-import os
-import string
 import unittest
 
 
@@ -149,3 +152,14 @@ class TestUtils(unittest.TestCase):
         """Test resolve_dep with bad OS"""
         with self.assertRaises(UnknownPlatform):
             ret = resolve_dep('cmake', 'Windoughs8')
+
+    def test_get_pr_text(self):
+        """Test get PR text"""
+        tmp = sys.argv
+        sys.argv = ['a', 'b', 'c', 'd']
+        expected = 'To reproduce this PR, run the following command.\n\n'\
+                   '```\na b c d\n```\n'
+        self.assertEqual(expected, get_pr_text())
+        # test with an argument
+        expected = 'sample\n'
+        self.assertEqual(expected, get_pr_text('sample'))

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -179,6 +179,7 @@ class TestUtils(unittest.TestCase):
         self.assertEqual(expected, get_pr_text('sample'))
 
     def test_cleanup(self):
+        """Test PR dry run cleanup"""
         # should pass
         clean_up()
         # should remove files
@@ -191,3 +192,9 @@ class TestUtils(unittest.TestCase):
             clean_up()
             self.assertFalse(os.path.exists('%s/.pr-message.tmp' % tempdir))
             self.assertFalse(os.path.exists('%s/.pr-title.tmp' % tempdir))
+
+    def test_resolve_dep_oe(self):
+        """Test resolve dependency with Open Embedded"""
+        # Note(allenh1): we're not going to test the hard-coded resolutions.
+        self.assertEqual(resolve_dep('tinyxml2', 'oe'), 'libtinyxml2')
+        self.assertEqual(resolve_dep('p2os_msgs', 'oe'), 'p2os-msgs')


### PR DESCRIPTION
```
$ coverage run --source=superflore -m nose && coverage report -m
........................................................
----------------------------------------------------------------------
Ran 56 tests in 14.888s

OK
Name                                               Stmts   Miss  Cover   Missing
--------------------------------------------------------------------------------
superflore/CacheManager.py                            20      0   100%
superflore/PackageMetadata.py                         22      0   100%
superflore/TempfileManager.py                         34      6    82%   48-56
superflore/__init__.py                                10      4    60%   5-8
superflore/docker.py                                  78     23    71%   42, 56-69, 75, 93-95, 102, 107-108, 119-127
superflore/exceptions.py                              18      2    89%   33, 38
superflore/generate_installers.py                     63      0   100%
superflore/generators/__init__.py                      0      0   100%
superflore/generators/bitbake/__init__.py              3      1    67%   3
superflore/generators/bitbake/gen_packages.py        102     79    23%   40-122, 129-168, 175-183, 189
superflore/generators/bitbake/ros_meta.py             27     18    33%   24-27, 30-35, 38-51, 54-55
superflore/generators/bitbake/run.py                 113     90    20%   43-187
superflore/generators/bitbake/yocto_recipe.py        120    100    17%   44-67, 70, 73-77, 80-92, 95-99, 102-104, 107-108, 116-119, 128-187
superflore/generators/ebuild/__init__.py               3      1    67%   3
superflore/generators/ebuild/ebuild.py               185     19    90%   96-99, 126-131, 146, 176-180, 186, 193, 206-210
superflore/generators/ebuild/gen_packages.py         140    113    19%   46-119, 125-137, 143-188, 193-210, 213, 216
superflore/generators/ebuild/metadata_xml.py          33      0   100%
superflore/generators/ebuild/overlay_instance.py      35     24    31%   26-31, 34-45, 50-69, 72-73
superflore/generators/ebuild/run.py                  121     95    21%   48-188, 192-196
superflore/parser.py                                  13      0   100%
superflore/repo_instance.py                           70     51    27%   29-49, 56-65, 68-76, 82-83, 89, 95-96, 102, 105-120, 123
superflore/rosdep_support.py                          34      2    94%   83-84
superflore/test_integration/__init__.py                0      0   100%
superflore/test_integration/gentoo/__init__.py         3      1    67%   3
superflore/test_integration/gentoo/build_base.py      28     19    32%   26-28, 33, 38-54
superflore/test_integration/gentoo/main.py            32     26    19%   24-80
superflore/utils.py                                  191     32    83%   62-65, 69-84, 88-99, 116, 229, 233, 235, 237, 239, 241, 243, 245, 247
--------------------------------------------------------------------------------
TOTAL                                               1498    706    53%
```

This also includes an important fix for the PR text. Not sure when exactly it got pulled in, or how I didn't notice it, but it's a rather obvious bug fix.