### PR TITLE
Add Upstream Options to Check Ebuild Command

### DIFF
--- a/superflore/generators/ebuild/overlay_instance.py
+++ b/superflore/generators/ebuild/overlay_instance.py
@@ -83,7 +83,7 @@ class RosOverlay(object):
 
     def get_last_modified(self, branch='master'):
         self.repo.change_branch(branch)
-        return get_changes_from_commit(self.repo.get_last_hash())
+        return self.get_changes_from_commit(self.repo.get_last_hash())
 
     def get_changes_from_commit(self, commit):
         files_changed = self.repo.get_files_changed_by_commit(commit)

--- a/superflore/generators/ebuild/overlay_instance.py
+++ b/superflore/generators/ebuild/overlay_instance.py
@@ -81,7 +81,8 @@ class RosOverlay(object):
         pr_title = 'rosdistro sync, {0}'.format(time.ctime())
         self.repo.pull_request(message, pr_title)
 
-    def get_last_modified(self):
+    def get_last_modified(self, branch='master'):
+        self.git.change_branch(branch)
         files_changed = self.repo.get_files_changed_by_commit(
             self.repo.get_last_hash()
         )

--- a/superflore/generators/ebuild/overlay_instance.py
+++ b/superflore/generators/ebuild/overlay_instance.py
@@ -23,13 +23,16 @@ from superflore.utils import rand_ascii_str
 
 
 class RosOverlay(object):
-    def __init__(self, repo_dir, do_clone, org='ros', repo='ros-overlay'):
+    def __init__(
+        self, repo_dir, do_clone, org='ros', repo='ros-overlay', mkbranch=True
+    ):
         self.repo = RepoInstance(
             org, repo, repo_dir=repo_dir, do_clone=do_clone
         )
-        self.branch_name = 'gentoo-bot-%s' % rand_ascii_str()
-        info('Creating new branch {0}...'.format(self.branch_name))
-        self.repo.create_branch(self.branch_name)
+        if mkbranch:
+            self.branch_name = 'gentoo-bot-%s' % rand_ascii_str()
+            info('Creating new branch {0}...'.format(self.branch_name))
+            self.repo.create_branch(self.branch_name)
 
     def commit_changes(self, distro):
         info('Adding changes...')
@@ -77,3 +80,11 @@ class RosOverlay(object):
     def pull_request(self, message, overlay=None):
         pr_title = 'rosdistro sync, {0}'.format(time.ctime())
         self.repo.pull_request(message, pr_title)
+
+    def get_last_modified(self):
+        files_changed = self.repo.get_files_changed_by_commit(
+            self.repo.get_last_hash()
+        )
+        # trim the end directory and make unique
+        ret = list(set(['/'.join(f.split('/')[:2]) for f in files_changed]))
+        return ret

--- a/superflore/generators/ebuild/overlay_instance.py
+++ b/superflore/generators/ebuild/overlay_instance.py
@@ -82,10 +82,10 @@ class RosOverlay(object):
         self.repo.pull_request(message, pr_title)
 
     def get_last_modified(self, branch='master'):
-        self.git.change_branch(branch)
-        files_changed = self.repo.get_files_changed_by_commit(
-            self.repo.get_last_hash()
-        )
+        self.repo.change_branch(branch)
+        return get_changes_from_commit(self.repo.get_last_hash())
+
+    def get_changes_from_commit(self, commit):
+        files_changed = self.repo.get_files_changed_by_commit(commit)
         # trim the end directory and make unique
-        ret = list(set(['/'.join(f.split('/')[:2]) for f in files_changed]))
-        return ret
+        return list(set(['/'.join(f.split('/')[:2]) for f in files_changed]))

--- a/superflore/repo_instance.py
+++ b/superflore/repo_instance.py
@@ -121,3 +121,9 @@ class RepoInstance(object):
 
     def get_last_hash(self):
         return self.repo.head.object.hexsha
+
+    def get_files_changed_by_commit(self, commit):
+        # get a list of files changed by the given commit
+        return self.repo.git.diff_tree(
+            '--no-commit-id', '--name-only', '-r', commit
+        ).split('\n')

--- a/superflore/test_integration/gentoo/main.py
+++ b/superflore/test_integration/gentoo/main.py
@@ -54,6 +54,16 @@ def main():
         help='location to store the log file',
         type=str
     )
+    parser.add_argument(
+        '--set-upstream',
+        help='URL for the overlay to test',
+        type=str
+    )
+    parser.add_argument(
+        '--branch',
+        help='Branch to test',
+        type=str
+    )
     args = parser.parse_args(sys.argv[1:])
 
     if args.f:
@@ -71,6 +81,8 @@ def main():
     else:
         parser.error('Invalid args! You must supply a package list.')
         sys.exit(1)
+    if args.set_upstream:
+        tester.set_upstream(args.set_upstream, args.branch or 'master')
     results = tester.run(args.verbose, args.log_file)
     failures = 0
     for test_case in results.keys():

--- a/superflore/test_integration/gentoo/main.py
+++ b/superflore/test_integration/gentoo/main.py
@@ -69,6 +69,11 @@ def main():
         type=str
     )
     parser.add_argument(
+        '--from-commit',
+        help='test changes from a specific commit',
+        type=str
+    )
+    parser.add_argument(
         '--ci-mode',
         help='build packages from latest git commit',
         action="store_true"
@@ -100,7 +105,11 @@ def main():
         with TempfileManager(None) as _repo:
             os.chmod(_repo, 17407)
             overlay = RosOverlay(_repo, True, org=repo_org, repo=repo_name)
-            build_list = overlay.get_last_modified(args.branch or 'master')
+            build_list = []
+            if args.from_commit:
+                build_list = overlay.get_changes_from_commit(args.from_commit)
+            else:
+                build_list = overlay.get_last_modified(args.branch or 'master')
         for p in build_list:
             tester.package_list[p] = 'unknown'
     results = tester.run(args.verbose, args.log_file)

--- a/superflore/test_integration/gentoo/main.py
+++ b/superflore/test_integration/gentoo/main.py
@@ -100,7 +100,7 @@ def main():
         with TempfileManager(None) as _repo:
             os.chmod(_repo, 17407)
             overlay = RosOverlay(_repo, True, org=repo_org, repo=repo_name)
-            build_list = overlay.get_last_modified()
+            build_list = overlay.get_last_modified(args.branch or 'master')
         for p in build_list:
             tester.package_list[p] = 'unknown'
     results = tester.run(args.verbose, args.log_file)


### PR DESCRIPTION
```
$ superflore-check-ebuilds --set-upstream https://github.com/allenh1/ros-overlay --pkgs ros --ros-distro lunar -v
```

This allows us to test ebuilds from specific remotes (other than the default).

I'd like to add a `--from-commit` option before I merge this, which would detect the changed packages and attempt to build them (but that's a work in progress for sure).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ros-infrastructure/superflore/151)
<!-- Reviewable:end -->
