### PR TITLE
Reference the LICENSE file from stdeb.cfg

### DIFF
--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -1,4 +1,5 @@
 [DEFAULT]
 Depends3: python3-rospkg (>= 1.0.37), python3-yaml, python3-catkin-pkg (>= 0.4.0), python3-rosdistro (>= 0.4.0), python3-termcolor, python3-xmltodict, python3-rosinstall-generator, python-rosdep, python3-github, python3-docker, python3-git, git, docker-ce
+Copyright-File: LICENSE
 Suite: xenial yakkety zesty artful
 X-Python3-Version: >= 3.5


### PR DESCRIPTION
This will install it properly for debs.