### PR TITLE
Enforce python 3 requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,9 @@
 import sys
 from setuptools import find_packages, setup
 
+if sys.version_info < (3, 0):
+    sys.exit('Sorry, Python < 3.0 is not supported')
+
 install_requires = [
     'xmltodict',
     'termcolor',
@@ -27,6 +30,7 @@ setup(
     url='https://github.com/ros-infrastructure/superflore',
     keywords=['ROS'],
     install_requires=install_requires,
+    python_requires='>=3',
     classifiers=['Programming Language :: Python',
                  'License :: OSI Approved :: Apache Software License'],
     description='Super Bloom',


### PR DESCRIPTION
Python 2 support was dropped in bf9d23bebf683fc09f1b7225713d7cc66a4df26c, but there doesn't seem to be any indication of this (besides lack of testing in Travis).

Also, I was able to install this for python 2 via pip.

Feel free to make the requirement a little more specific.