### PR TITLE
Reduce distro hardcoding

### DIFF
--- a/superflore/generators/bitbake/ros_meta.py
+++ b/superflore/generators/bitbake/ros_meta.py
@@ -40,17 +40,13 @@ class RosMeta(object):
             self.repo.git.add('recipes-ros-*')
         else:
             self.repo.git.add('recipes-ros-{0}'.format(distro))
-        commit_msg = {
-            'update': 'rosdistro sync, {0}',
-            'all': 'regenerate all distros, {0}',
-            'lunar': 'regenerate ros-lunar, {0}',
-            'indigo': 'regenerate ros-indigo, {0}',
-            'kinetic': 'regenerate ros-kinetic, {0}',
-            'melodic': 'regenerate ros-melodic, {0}',
-            'ardent': 'regenerate ros2-ardent, {0}',
-            'bouncy': 'regenerate ros2-bouncy, {0}',
-            'crystal': 'regenerate ros2-crystal, {0}',
-        }[distro].format(time.ctime())
+        if distro == 'update':
+            commit_msg = 'rosdistro sync, {0}'
+        elif distro == 'all':
+            commit_msg = 'regenerate all distros, {0}'
+        else:
+            commit_msg = 'regenerate ros-{1}, {0}'
+        commit_msg = commit_msg.format(time.ctime(), distro)
         info('Committing to branch {0}...'.format(self.branch_name))
         self.repo.git.commit(m='{0}'.format(commit_msg))
 

--- a/superflore/generators/ebuild/overlay_instance.py
+++ b/superflore/generators/ebuild/overlay_instance.py
@@ -35,17 +35,13 @@ class RosOverlay(object):
         info('Adding changes...')
         self.repo.git.add(self.repo.repo_dir)
         info('Committing to branch {0}...'.format(self.branch_name))
-        commit_msg = {
-            'update': 'rosdistro sync, ',
-            'all': 'regenerate all distros, ',
-            'lunar': 'regenerate ros-lunar, ',
-            'indigo': 'regenerate ros-indigo, ',
-            'kinetic': 'regenerate ros-kinetic, ',
-            'melodic': 'regenerate ros-melodic, ',
-            'ardent': 'regenerate ros2-ardent, ',
-            'bouncy': 'regenerate ros2-bouncy, ',
-            'crystal': 'regenerate ros2-crystal, ',
-        }[distro or 'update'] + time.ctime()
+        if distro == 'update':
+            commit_msg = 'rosdistro sync, {0}'
+        elif distro == 'all':
+            commit_msg = 'regenerate all distros, {0}'
+        else:
+            commit_msg = 'regenerate ros-{1}, {0}'
+        commit_msg = commit_msg.format(time.ctime(), distro)
         self.repo.git.commit(m='{0}'.format(commit_msg))
 
     def regenerate_manifests(

--- a/superflore/utils.py
+++ b/superflore/utils.py
@@ -29,7 +29,7 @@ from termcolor import colored
 # TODO(nuclearsandwich) use the index v4 to query for active ROS and ROS 2
 # distributions.
 active_distros = ['indigo', 'kinetic', 'lunar', 'melodic']
-ros2_distros = ['ardent', 'bouncy', 'crystal']
+ros2_distros = ['ardent', 'bouncy', 'crystal', 'dashing']
 
 
 def warn(string):  # pragma: no cover

--- a/superflore/utils.py
+++ b/superflore/utils.py
@@ -26,6 +26,8 @@ from superflore.rosdep_support import resolve_rosdep_key
 from termcolor import colored
 
 # Modify if a new distro is added
+# TODO(nuclearsandwich) use the index v4 to query for active ROS and ROS 2
+# distributions.
 active_distros = ['indigo', 'kinetic', 'lunar', 'melodic']
 ros2_distros = ['ardent', 'bouncy', 'crystal']
 


### PR DESCRIPTION
Opened as an alternative to #171.

This PR reducing the amount of rosdistro hard-coding in commit message formatting. There is only one change in the generated text (unless I've made an error) which is that commit messages for ROS 2 distributions will now say `ros-ROSDISTRO, TIMESTAMP` rather than `ros2-ROSDISTRO, TIMEPSTAMP`. I believe this change to be acceptable given the simplification it enables.

I would have liked to remove the last hard-coded list of active ROS and ROS 2 distros but I only gave myself 10 minutes to make this change. I'd have no problem if @allenh1 or @andre-rosa wanted to address the TODO before this is merged. I do not know when I would have time to return to it.

In case we decide to merge the incremental improvement I also added dashing to the final hard-coded list so this PR should replace #171 as-is with similar functionality.