### PR TITLE
Pass distro to generate_installer

### DIFF
--- a/superflore/generate_installers.py
+++ b/superflore/generate_installers.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from rosinstall_generator.distro import get_distro
 from rosinstall_generator.distro import get_package_names
 from superflore.exceptions import UnknownBuildType
 from superflore.exceptions import UnknownLicense
@@ -24,14 +23,14 @@ from superflore.utils import warn
 
 
 def generate_installers(
-    distro_name,             # ros distro name
+    distro,                  # ros distro
     overlay,                 # repo instance
     gen_pkg_func,            # function to call for generating
     preserve_existing=True,  # don't regenerate if installer exists
     *args,                   # any additional args for gen_pkg_func
     **kwargs                 # any additional keyword arguments
 ):
-    distro = get_distro(distro_name)
+    distro_name = distro._distribution_file.name
     pkg_names = get_package_names(distro)
     total = float(len(pkg_names[0]))
     borkd_pkgs = dict()

--- a/superflore/generate_installers.py
+++ b/superflore/generate_installers.py
@@ -30,7 +30,7 @@ def generate_installers(
     *args,                   # any additional args for gen_pkg_func
     **kwargs                 # any additional keyword arguments
 ):
-    distro_name = distro._distribution_file.name
+    distro_name = distro.name
     pkg_names = get_package_names(distro)
     total = float(len(pkg_names[0]))
     borkd_pkgs = dict()

--- a/superflore/generators/bitbake/run.py
+++ b/superflore/generators/bitbake/run.py
@@ -157,7 +157,7 @@ def main():
             for distro in selected_targets:
                 distro_installers, distro_broken, distro_changes =\
                     generate_installers(
-                        distro,
+                        get_distro(distro),
                         overlay,
                         regenerate_installer,
                         preserve_existing,

--- a/superflore/generators/ebuild/run.py
+++ b/superflore/generators/ebuild/run.py
@@ -142,7 +142,7 @@ def main():
         for distro in selected_targets:
             distro_installers, distro_broken, distro_changes =\
                 generate_installers(
-                    distro_name=distro,
+                    get_distro(distro),
                     overlay=overlay,
                     gen_pkg_func=regenerate_pkg,
                     preserve_existing=preserve_existing,

--- a/tests/test_generate_installers.py
+++ b/tests/test_generate_installers.py
@@ -14,6 +14,7 @@
 
 import re
 
+from rosinstall_generator.distro import get_distro
 from superflore.exceptions import UnknownBuildType
 from superflore.exceptions import UnknownLicense
 from superflore.generate_installers import generate_installers
@@ -69,7 +70,7 @@ class TestGenerateInstallers(unittest.TestCase):
         acc = list()
         # attempt to generate the installers
         inst, broken, changes = generate_installers(
-            'lunar', None, _gen_package, False, acc
+            get_distro('lunar'), None, _gen_package, False, acc
         )
         # since we don't do anything, there should be no failures.
         self.assertEqual(broken,{})
@@ -80,7 +81,7 @@ class TestGenerateInstallers(unittest.TestCase):
         """Test for an unresolved dependency"""
         acc = list()
         inst, broken, changes = generate_installers(
-            'lunar', None, _fail_if_p2os, False, acc
+            get_distro('lunar'), None, _fail_if_p2os, False, acc
         )
         broken = [b for b in broken]
         total_list = inst + broken
@@ -95,7 +96,7 @@ class TestGenerateInstallers(unittest.TestCase):
         """Test how skipped packages are handled"""
         acc = list()
         inst, broken, changes = generate_installers(
-            'lunar', None, _skip_if_p2os, True, acc
+            get_distro('lunar'), None, _skip_if_p2os, True, acc
         )
         broken = [b for b in broken]
         total_list = inst + broken
@@ -110,7 +111,7 @@ class TestGenerateInstallers(unittest.TestCase):
         """Test exceptions"""
         acc = list()
         inst, broken, changes = generate_installers(
-            'lunar', None, _raise_exceptions, True, acc
+            get_distro('lunar'), None, _raise_exceptions, True, acc
         )
         # anything with a 'k', 'l', or a 'b' has been skipped
         for p in inst:
@@ -123,7 +124,7 @@ class TestGenerateInstallers(unittest.TestCase):
         changes_re = '\*(([a-zA-Z]|\_|[0-9])+)\ [0-9]\.[0-9]\.[0-9]("-r"[0-9])?\*'
         acc = list()
         inst, broken, changes = generate_installers(
-            'lunar', None, _create_if_p2os, True, acc
+            get_distro('lunar'), None, _create_if_p2os, True, acc
         )
         found = False
         for c in changes:


### PR DESCRIPTION
  * OpenEmbedded generation will need information from distro from
    run.py, so allow run.py to get_distro() just once and pass it to
    generate_installer(), like it's done for regenerate_installer().