### PR TITLE
Pass along unknown licenses unclassified

### DIFF
--- a/superflore/exceptions.py
+++ b/superflore/exceptions.py
@@ -13,11 +13,6 @@
 # limitations under the License.
 
 
-class UnknownLicense(Exception):
-    def __init__(self, message):
-        self.message = message
-
-
 class UnresolvedDependency(Exception):
     def __init__(self, message):
         self.message = message

--- a/superflore/generate_installers.py
+++ b/superflore/generate_installers.py
@@ -14,7 +14,6 @@
 
 from rosinstall_generator.distro import get_package_names
 from superflore.exceptions import UnknownBuildType
-from superflore.exceptions import UnknownLicense
 from superflore.utils import err
 from superflore.utils import get_pkg_version
 from superflore.utils import info
@@ -75,10 +74,6 @@ def generate_installers(
             else:
                 changes.append('*{0} {1}*'.format(pkg, version))
             installers.append(pkg)
-        except UnknownLicense as ul:
-            err("{0}%: Unknown License '{1}'.".format(percent, str(ul)))
-            bad_installers.append(pkg)
-            failed = failed + 1
         except UnknownBuildType as ub:
             err(
                 "{0}%: Unknown Build type '{1}' for package '{2}'".format(

--- a/superflore/utils.py
+++ b/superflore/utils.py
@@ -20,7 +20,6 @@ import string
 import sys
 import time
 
-from superflore.exceptions import UnknownLicense
 from superflore.exceptions import UnknownPlatform
 from superflore.rosdep_support import get_cached_index, resolve_rosdep_key
 from termcolor import colored
@@ -199,8 +198,8 @@ def get_license(l):
     elif re.search(pub_dom_re, l, f):
         return 'public_domain'
     else:
-        err('Could not match license "{0}".'.format(l))
-        raise UnknownLicense('bad license')
+        warn('Could not match license "{0}". Passing it through...'.format(l))
+        return l
 
 
 def resolve_dep(pkg, os, distro=None):

--- a/tests/test_generate_installers.py
+++ b/tests/test_generate_installers.py
@@ -16,7 +16,6 @@ import re
 
 from rosinstall_generator.distro import get_distro
 from superflore.exceptions import UnknownBuildType
-from superflore.exceptions import UnknownLicense
 from superflore.generate_installers import generate_installers
 import unittest
 
@@ -55,9 +54,7 @@ def _create_if_p2os(overlay, pkg, distro, preserve_existing, collector):
 def _raise_exceptions(overlay, pkg, distro, preserve_existing, collector):
     """Raise exceptions"""
     collector.append(pkg)
-    if 'l' in pkg:
-        raise UnknownLicense('l')
-    elif 'b' in pkg:
+    if 'b' in pkg:
         raise UnknownBuildType('b')
     elif 'k' in pkg:
         raise KeyError('k')
@@ -116,7 +113,6 @@ class TestGenerateInstallers(unittest.TestCase):
         # anything with a 'k', 'l', or a 'b' has been skipped
         for p in inst:
             self.assertNotIn('k', p)
-            self.assertNotIn('l', p)
             self.assertNotIn('b', p)
 
     def test_changes(self):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -16,7 +16,6 @@ import os
 import string
 import sys
 
-from superflore.exceptions import UnknownLicense
 from superflore.exceptions import UnknownPlatform
 from superflore.TempfileManager import TempfileManager
 from superflore.utils import clean_up
@@ -119,8 +118,8 @@ class TestUtils(unittest.TestCase):
         self.assertEqual(ret, 'MIT')
         ret = get_license('Creative Commons')
         self.assertEqual(ret, 'CC-BY-SA-3.0')
-        with self.assertRaises(UnknownLicense):
-            ret = get_license('TODO')
+        ret = get_license('United States Government Purpose')
+        self.assertEqual(ret, 'United States Government Purpose')
 
     def test_delta_msg(self):
         """Test the delta message generated for the PR"""


### PR DESCRIPTION
- Fixes #184 generating qt_metapackages recipes in Melodic
- Currently Proprietary and United States Government Purpose licenses
  aren't matched in SuperFlore and it aborts generation of some melodic
  packages like qt_metapackages/libqt_core
  https://github.com/swri-robotics/qt_metapackages/blob/master/libqt_core/package.xml
- With the patch, license is output as:
  ...
  LICENSE = "United States Government Purpose & SwRI Proprietary"
  LIC_FILES_CHKSUM = "file://package.xml;beginline=11;endline=11;md5=8e473b26ead33548c945bdaca143a08d"
    ...