### PR TITLE
Fix gen_pkg_func failure not being recorded by generate_installers

### DIFF
--- a/superflore/generate_installers.py
+++ b/superflore/generate_installers.py
@@ -50,17 +50,18 @@ def generate_installers(
             current, current_info = gen_pkg_func(
                 overlay, pkg, distro, preserve_existing, *args
             )
-            if not current and current_info:
-                # we are missing dependencies
+            if not current:
+                if preserve_existing:
+                    # don't replace the installer
+                    succeeded = succeeded + 1
+                    continue
+                if current_info:
+                    # we are missing dependencies
+                    borkd_pkgs[pkg] = current_info
                 failed_msg = "{0}%: Failed to generate".format(percent)
                 failed_msg += " installer for package '%s'!" % pkg
                 err(failed_msg)
-                borkd_pkgs[pkg] = current_info
                 failed = failed + 1
-                continue
-            elif not current and preserve_existing:
-                # don't replace the installer
-                succeeded = succeeded + 1
                 continue
             success_msg = 'Successfully generated installer for package'
             ok('{0}%: {1} \'{2}\'.'.format(percent, success_msg, pkg))


### PR DESCRIPTION
generate_installers() didn't consider a few gen_pkg_func() failure
situations like:

  - InvalidPackage:
    The manifest contains invalid XML: syntax error: line 1, column 0
    !!!! 61.7%: Failed to generate installer for package 'qb_chain'!
  - NoPkgXml: Could not fetch pkg!

Those are signaled by gen_pkg_func by returning no installer (None)
and no missing dependencies ([]).

Whenever gen_pkg_func() returns no installer, it must be an error except
when we want to preserve_existing.

Fixes #186 .