### PR TITLE
Retry XML downloads

### DIFF
--- a/superflore/generators/bitbake/gen_packages.py
+++ b/superflore/generators/bitbake/gen_packages.py
@@ -155,10 +155,10 @@ def _gen_recipe_for_package(
         pkg_recipe.add_depend(tdep)
 
     # parse throught package xml
-    final_error_msg = f'Failed to fetch metadata for package {pkg_name}'
+    error_msg = 'Failed to fetch metadata for package {}'.format(pkg_name)
     pkg_xml = retry_on_exception(ros_pkg.get_package_xml, distro.name,
                                  retry_msg='Could not get package xml!',
-                                 error_msg=final_error_msg)
+                                 error_msg=error_msg)
     pkg_fields = PackageMetadata(pkg_xml)
     pkg_recipe.pkg_xml = pkg_xml
     pkg_recipe.license = pkg_fields.upstream_license

--- a/superflore/generators/bitbake/gen_packages.py
+++ b/superflore/generators/bitbake/gen_packages.py
@@ -28,7 +28,7 @@ from superflore.utils import err
 from superflore.utils import get_pkg_version
 from superflore.utils import make_dir
 from superflore.utils import ok
-from superflore.utils import warn
+from superflore.utils import retry_on_exception
 
 org = "Open Source Robotics Foundation"
 org_license = "BSD"
@@ -155,11 +155,10 @@ def _gen_recipe_for_package(
         pkg_recipe.add_depend(tdep)
 
     # parse throught package xml
-    try:
-        pkg_xml = ros_pkg.get_package_xml(distro.name)
-    except Exception:
-        warn("fetch metadata for package {}".format(pkg_name))
-        return pkg_recipe
+    final_error_msg = f'Failed to fetch metadata for package {pkg_name}'
+    pkg_xml = retry_on_exception(ros_pkg.get_package_xml, distro.name,
+                                 retry_msg='Could not get package xml!',
+                                 error_msg=final_error_msg)
     pkg_fields = PackageMetadata(pkg_xml)
     pkg_recipe.pkg_xml = pkg_xml
     pkg_recipe.license = pkg_fields.upstream_license

--- a/superflore/generators/ebuild/gen_packages.py
+++ b/superflore/generators/ebuild/gen_packages.py
@@ -29,6 +29,7 @@ from superflore.utils import get_distros
 from superflore.utils import get_pkg_version
 from superflore.utils import make_dir
 from superflore.utils import ok
+from superflore.utils import retry_on_exception
 from superflore.utils import warn
 
 # TODO(allenh1): This is a blacklist of things that
@@ -124,7 +125,7 @@ def _gen_metadata_for_package(
 ):
     pkg_metadata_xml = metadata_xml()
     try:
-        pkg_xml = ros_pkg.get_package_xml(distro.name)
+        pkg_xml = retry_on_exception(ros_pkg.get_package_xml, distro.name)
     except Exception:
         warn("fetch metadata for package {}".format(pkg_name))
         return pkg_metadata_xml
@@ -176,7 +177,7 @@ def _gen_ebuild_for_package(
 
     # parse through package xml
     try:
-        pkg_xml = ros_pkg.get_package_xml(distro.name)
+        pkg_xml = retry_on_exception(ros_pkg.get_package_xml, distro.name)
     except Exception:
         warn("fetch metadata for package {}".format(pkg_name))
         return pkg_ebuild

--- a/superflore/utils.py
+++ b/superflore/utils.py
@@ -295,11 +295,13 @@ def retry_on_exception(callback, *args, max_retries=5, num_retry=0,
     except Exception as e:
         if num_retry >= max_retries or max_retries < 0 or num_retry < 0:
             if error_msg:
-                err(f'{e} {error_msg} {num_retry}/{max_retries}')
+                err('{0} {1} {2}/{3}'.format(str(e), error_msg,
+                    num_retry, max_retries))
             raise e from None
         if num_retry > 0:
             if retry_msg:
-                warn(f'{e} {retry_msg} {num_retry}/{max_retries}...')
+                warn('{0} {1} {2}/{3}...'.format(str(e), retry_msg,
+                     num_retry, max_retries))
             time.sleep(sleep_secs)
             if num_retry <= 6:
                 sleep_secs *= 2

--- a/superflore/utils.py
+++ b/superflore/utils.py
@@ -286,3 +286,18 @@ def url_to_repo_org(url):
         )
     url = url.replace('https://github.com/', '').split('/')
     return url[0], url[1]
+
+
+def retry_on_exception(callback, *args, retries=5, retry_msg='', error_msg=''):
+    for retry in range(1, retries+1):
+        try:
+            ret = callback(*args)
+        except Exception as e:
+            if retry == retries:
+                if error_msg:
+                    err(f'{error_msg} {e} {retry}/{retries}')
+                raise e
+            if retry_msg:
+                warn(f'{retry_msg} {e} {retry}/{retries}...')
+        else:
+            return ret

--- a/superflore/utils.py
+++ b/superflore/utils.py
@@ -289,9 +289,14 @@ def url_to_repo_org(url):
 
 
 def retry_on_exception(callback, *args, retries=5, retry_msg='', error_msg=''):
+    try:
+        return callback(*args)
+    except Exception as e:
+        if retries <= 0:
+            raise e
     for retry in range(1, retries+1):
         try:
-            ret = callback(*args)
+            return callback(*args)
         except Exception as e:
             if retry == retries:
                 if error_msg:
@@ -299,5 +304,3 @@ def retry_on_exception(callback, *args, retries=5, retry_msg='', error_msg=''):
                 raise e
             if retry_msg:
                 warn(f'{retry_msg} {e} {retry}/{retries}...')
-        else:
-            return ret


### PR DESCRIPTION
  - Adds a retry mechanism to the XML downloads. It makes generation more
    robust upon transient failures of the download which occurs more often
    than not. Normally downloads work fine just by retrying them.
  - Fixes #188 .