### PR TITLE
Change Back to apt-get for CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,9 @@ python:
 before_install:
   - sudo echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" | sudo tee -a /etc/apt/sources.list.d/ros-latest.list
   - sudo apt-key adv --keyserver hkp://ha.pool.sks-keyservers.net:80 --recv-key C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
-  - sudo apt update -qq
-  - sudo apt install dpkg -y
-  - sudo apt install -y python-rosdep
+  - sudo apt-get update -qq
+  - sudo apt-get install dpkg -y
+  - sudo apt-get install -y python-rosdep
 # command to install dependencies
 install:
   - pip install -r requirements.txt


### PR DESCRIPTION
Use apt-get instead of apt for API stability

Signed-off-by: Hunter L. Allen <hunterlallen@protonmail.com>

---

see comments in #199 