### PR TITLE
Make markdown optional for generating the PR and commit messages

### DIFF
--- a/superflore/generate_installers.py
+++ b/superflore/generate_installers.py
@@ -68,12 +68,12 @@ def generate_installers(
             succeeded += 1
             if current_info:
                 changes.append(
-                    '*{0} {1} --> {2}*'.format(
+                    '{0} {1} --> {2}'.format(
                         pkg, current_info, version
                     )
                 )
             else:
-                changes.append('*{0} {1}*'.format(pkg, version))
+                changes.append('{0} {1}'.format(pkg, version))
             installers.append(pkg)
         except UnknownBuildType as ub:
             err(

--- a/superflore/utils.py
+++ b/superflore/utils.py
@@ -42,14 +42,14 @@ def info(string):  # pragma: no cover
     print(colored('>>>> {0}'.format(string), 'cyan'))
 
 
-def get_pr_text(comment=None):
+def get_pr_text(comment=None, markup='```'):
     msg = ''
     if comment:
         msg += '%s\n' % comment
     msg += 'To reproduce this PR, run the following command.\n\n'
     args = sys.argv
     args[0] = args[0].split('/')[-1]
-    msg += '```\n%s\n```' % ' '.join(args) + '\n'
+    msg += '{1}\n{0}\n{1}\n'.format(' '.join(args), markup)
     return msg
 
 
@@ -224,17 +224,20 @@ def get_distros_by_status(status='active'):
             if t[1].get('distribution_status') == status]
 
 
-def gen_delta_msg(total_changes):
+def gen_delta_msg(total_changes, markup='*'):
     """Return string of changes for the PR message."""
-    delta = "Changes:\n"
-    delta += "========\n"
+    delta = ''
+    is_single_distro = len(total_changes) == 1
+    distro_header = '#'
+    if not is_single_distro:
+        delta += "# Changes:\n"
+        distro_header *= 2
     for distro in sorted(total_changes):
         if not total_changes[distro]:
             continue
-        delta += "%s Changes:\n" % distro.title()
-        delta += "---------------\n"
+        delta += "{} {} Changes:\n".format(distro_header, distro.title())
         for d in sorted(total_changes[distro]):
-            delta += '* {0}\n'.format(d)
+            delta += '* {1}{0}{1}\n'.format(d, markup)
         delta += "\n"
     return delta
 

--- a/tests/test_generate_installers.py
+++ b/tests/test_generate_installers.py
@@ -117,7 +117,7 @@ class TestGenerateInstallers(unittest.TestCase):
 
     def test_changes(self):
         """Tests changes represented by generate installers"""
-        changes_re = '\*(([a-zA-Z]|\_|[0-9])+)\ [0-9]\.[0-9]\.[0-9]("-r"[0-9])?\*'
+        changes_re = '(([a-zA-Z]|\_|[0-9])+)\ [0-9]\.[0-9]\.[0-9]("-r"[0-9])?'
         acc = list()
         inst, broken, changes = generate_installers(
             get_distro('lunar'), None, _create_if_p2os, True, acc

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -134,15 +134,12 @@ class TestUtils(unittest.TestCase):
         total_changes['hydro'] = ['foo', 'bar']
         total_changes['boxturtle'] = ['baz']
         total_changes['C'] = []
-        expect = 'Changes:\n'\
-                 '========\n'\
-                 'Boxturtle Changes:\n'\
-                 '---------------\n'\
-                 '* baz\n\n'\
-                 'Hydro Changes:\n'\
-                 '---------------\n'\
-                 '* bar\n'\
-                 '* foo\n\n'
+        expect = '# Changes:\n'\
+                 '## Boxturtle Changes:\n'\
+                 '* *baz*\n\n'\
+                 '## Hydro Changes:\n'\
+                 '* *bar*\n'\
+                 '* *foo*\n\n'
         got = gen_delta_msg(total_changes)
         self.assertEqual(expect, got)
 


### PR DESCRIPTION
  - Maintains current behavior where markdown is added by default
  - PRs continue using markdown and commit descriptions will not
  - Modify header formatting markdown for a more succinct syntax

Fixes #209 .