### PR TITLE
Use branch based on UTC timestamp instead of random characters

### DIFF
--- a/superflore/generators/bitbake/ros_meta.py
+++ b/superflore/generators/bitbake/ros_meta.py
@@ -17,16 +17,15 @@ import time
 
 from superflore.repo_instance import RepoInstance
 from superflore.utils import info
-from superflore.utils import rand_ascii_str
 
 
 class RosMeta(object):
     def __init__(
-       self, repo_dir, do_clone, org='ros', repo='meta-ros', from_branch=''
+        self, dir, do_clone, branch, org='ros', repo='meta-ros', from_branch=''
     ):
         self.repo = RepoInstance(
-            org, repo, repo_dir, do_clone, from_branch=from_branch)
-        self.branch_name = 'yocto-bot-%s' % rand_ascii_str()
+            org, repo, dir, do_clone, from_branch=from_branch)
+        self.branch_name = branch
         info('Creating new branch {0}...'.format(self.branch_name))
         self.repo.create_branch(self.branch_name)
 

--- a/superflore/generators/bitbake/run.py
+++ b/superflore/generators/bitbake/run.py
@@ -30,6 +30,7 @@ from superflore.utils import file_pr
 from superflore.utils import gen_delta_msg
 from superflore.utils import gen_missing_deps_msg
 from superflore.utils import get_distros_by_status
+from superflore.utils import get_utcnow_timestamp_str
 from superflore.utils import info
 from superflore.utils import load_pr
 from superflore.utils import ok
@@ -78,6 +79,7 @@ def main():
         parser.error('Invalid args! --only requires specifying --ros-distro')
     if not selected_targets:
         selected_targets = get_distros_by_status('active')
+    now = get_utcnow_timestamp_str()
     repo_org = 'ros'
     repo_name = 'meta-ros'
     if args.upstream_repo:
@@ -91,6 +93,7 @@ def main():
         overlay = RosMeta(
             _repo,
             not args.output_repository_path,
+            branch='superflore/{}'.format(now),
             org=repo_org,
             repo=repo_name,
             from_branch=args.upstream_branch,

--- a/superflore/utils.py
+++ b/superflore/utils.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from datetime import datetime
 import errno
 import os
 import random
@@ -292,3 +293,7 @@ def get_superflore_version():
     except DistributionNotFound:
         version = 'Unknown'
     return version
+
+
+def get_utcnow_timestamp_str():
+    return datetime.utcnow().strftime('%Y%m%d%H%M%S')


### PR DESCRIPTION
  - OpenEmbedded branches follow format: 'superflore/<DATETIME>' (UTC)

Fixes #211 .