### PR TITLE
Update license classifier.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
     python_requires='>=3',
     classifiers=['Programming Language :: Python',
                  'License :: OSI Approved :: Apache Software License',
-                 'License :: OSI Approved :: MIT Software License'
+                 'License :: OSI Approved :: MIT License'
     ],
     description='Super Bloom',
     license='Apache 2.0',


### PR DESCRIPTION
The old one is no longer accepted.

It's been shortened: https://pypi.org/classifiers/

HTTPError: 400 Client Error: Invalid value for classifiers. Error: 'License :: OSI Approved :: MIT Software License' is not a valid choice for this field for url: https://upload.pypi.org/legacy/
Signed-off-by: Tully Foote <tfoote@osrfoundation.org>