### PR TITLE
Fix non-empty commit message for OpenEmbedded when no changes (#227)

### DIFF
--- a/superflore/generators/bitbake/gen_packages.py
+++ b/superflore/generators/bitbake/gen_packages.py
@@ -56,7 +56,7 @@ def regenerate_pkg(
         component_name,
         recipe,
     )
-    existing = glob.glob('{}*.bb'.format(prefix))
+    existing = glob.glob('{}_*.bb'.format(prefix))
     previous_version = None
     if preserve_existing and existing:
         ok("recipe for package '%s' up to date, skipping..." % pkg)


### PR DESCRIPTION
Fix a wild-card expansion that was accidentally matching more than just
version portion of recipe filenames.