### PR TITLE
Show OpenEmbedded recipe names in commit and PR messages (#225)

### DIFF
--- a/superflore/generate_installers.py
+++ b/superflore/generate_installers.py
@@ -47,7 +47,7 @@ def generate_installers(
         version = get_pkg_version(distro, pkg, **kwargs)
         percent = '%.1f' % (100 * (float(i) / total))
         try:
-            current, current_info = gen_pkg_func(
+            current, current_info, pkg_name_for_changes = gen_pkg_func(
                 overlay, pkg, distro, preserve_existing, *args
             )
             if not current:
@@ -67,11 +67,11 @@ def generate_installers(
             ok('{0}%: {1} \'{2}\'.'.format(percent, success_msg, pkg))
             succeeded += 1
             if not current_info:
-                changes.append('{0} {1}'.format(pkg, version))
+                changes.append('{0} {1}'.format(pkg_name_for_changes, version))
             elif current_info != version:
                 changes.append(
                     '{0} {1} --> {2}'.format(
-                        pkg, current_info, version
+                        pkg_name_for_changes, current_info, version
                     )
                 )
             installers.append(pkg)

--- a/superflore/generators/bitbake/gen_packages.py
+++ b/superflore/generators/bitbake/gen_packages.py
@@ -61,7 +61,7 @@ def regenerate_pkg(
     if preserve_existing and existing:
         ok("recipe for package '%s' up to date, skipping..." % pkg)
         yoctoRecipe.not_generated_recipes.add(pkg)
-        return None, []
+        return None, [], None
     elif existing:
         existing = existing[0]
         overlay.repo.remove_file(existing, True)
@@ -74,21 +74,21 @@ def regenerate_pkg(
     except InvalidPackage as e:
         err('Invalid package: ' + str(e))
         yoctoRecipe.not_generated_recipes.add(pkg)
-        return None, []
+        return None, [], None
     except Exception as e:
         err('Failed generating installer for {}! {}'.format(pkg, str(e)))
         yoctoRecipe.not_generated_recipes.add(pkg)
-        return None, []
+        return None, [], None
     try:
         recipe_text = current.recipe_text()
     except NoPkgXml as nopkg:
         err("Could not fetch pkg! {}".format(str(nopkg)))
         yoctoRecipe.not_generated_recipes.add(pkg)
-        return None, []
+        return None, [], None
     except KeyError as ke:
         err("Failed to parse data for package {}! {}".format(pkg, str(ke)))
         yoctoRecipe.not_generated_recipes.add(pkg)
-        return None, []
+        return None, [], None
     make_dir(
         "{0}/generated-recipes-{1}/{2}".format(
             repo_dir,
@@ -114,8 +114,8 @@ def regenerate_pkg(
     except Exception:
         err("Failed to write recipe to disk!")
         yoctoRecipe.not_generated_recipes.add(pkg)
-        return None, []
-    return current, previous_version
+        return None, [], None
+    return current, previous_version, recipe
 
 
 def _gen_recipe_for_package(

--- a/superflore/generators/ebuild/gen_packages.py
+++ b/superflore/generators/ebuild/gen_packages.py
@@ -66,7 +66,7 @@ def regenerate_pkg(overlay, pkg, distro, preserve_existing=False):
     previous_version = None
     if preserve_existing and os.path.isfile(ebuild_name):
         ok("ebuild for package '%s' up to date, skipping..." % pkg)
-        return None, []
+        return None, [], None
     elif existing:
         overlay.repo.remove_file(existing[0])
         previous_version = existing[0].lstrip(prefix).rstrip('.ebuild')
@@ -91,7 +91,7 @@ def regenerate_pkg(overlay, pkg, distro, preserve_existing=False):
         unresolved = current.ebuild.get_unresolved()
         for dep in unresolved:
             err(" unresolved: \"{}\"".format(dep))
-        return None, current.ebuild.get_unresolved()
+        return None, current.ebuild.get_unresolved(), None
     except KeyError as ke:
         err("Failed to parse data for package {}!".format(pkg))
         raise ke
@@ -117,7 +117,7 @@ def regenerate_pkg(overlay, pkg, distro, preserve_existing=False):
     except Exception as e:
         err("Failed to write ebuild/metadata to disk!")
         raise e
-    return current, previous_version
+    return current, previous_version, pkg
 
 
 def _gen_metadata_for_package(

--- a/tests/test_generate_installers.py
+++ b/tests/test_generate_installers.py
@@ -24,31 +24,31 @@ def _gen_package(overlay, pkg, distro, preserve_existing, collector):
     """This is just a stub. We just add to the collector"""
     collector.append(pkg)
     # return new installer, name it.
-    return True, pkg
+    return True, pkg, pkg
 
 
 def _fail_if_p2os(overlay, pkg, distro, preserve_existing, collector):
     """Fail if it's a p2os package"""
     collector.append(pkg)
     if 'p2os' in pkg:
-        return False, True
-    return True, True
+        return False, True, pkg
+    return True, True, pkg
 
 
 def _skip_if_p2os(overlay, pkg, distro, preserve_existing, collector):
     """Skip if it's a p2os package"""
     collector.append(pkg)
     if 'p2os' in pkg:
-        return False, False
-    return True, pkg
+        return False, False, pkg
+    return True, pkg, pkg
 
 
 def _create_if_p2os(overlay, pkg, distro, preserve_existing, collector):
     """Don't if the package is p2os"""
     collector.append(pkg)
     if 'p2os' in pkg:
-        return True, False
-    return True, True
+        return True, False, pkg
+    return True, True, pkg
 
 
 def _raise_exceptions(overlay, pkg, distro, preserve_existing, collector):
@@ -58,7 +58,7 @@ def _raise_exceptions(overlay, pkg, distro, preserve_existing, collector):
         raise UnknownBuildType('b')
     elif 'k' in pkg:
         raise KeyError('k')
-    return True, pkg
+    return True, pkg, pkg
 
 
 class TestGenerateInstallers(unittest.TestCase):


### PR DESCRIPTION
What's being committed are recipes, so show their names instead of the
ROS package names in the commit and PR messages.