### PR TITLE
Prevent accidental removal of headers when amending a commit (#228)

### DIFF
--- a/superflore/utils.py
+++ b/superflore/utils.py
@@ -232,14 +232,18 @@ def gen_delta_msg(total_changes, markup='*'):
     """Return string of changes for the PR message."""
     delta = ''
     is_single_distro = len(total_changes) == 1
-    distro_header = '#'
+    distro_header = '='
     if not is_single_distro:
-        delta += "# Changes:\n"
-        distro_header *= 2
+        delta += "Changes:\n"
+        delta += "========\n"
+        distro_header = '-'
     for distro in sorted(total_changes):
         if not total_changes[distro]:
             continue
-        delta += "{} {} Changes:\n".format(distro_header, distro.title())
+        heading = "{} Changes:\n".format(distro.title())
+        delta += heading
+        delta += distro_header * (len(heading) - 1)
+        delta += "\n"
         for d in sorted(total_changes[distro]):
             delta += '* {1}{0}{1}\n'.format(d, markup)
         delta += "\n"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -134,10 +134,13 @@ class TestUtils(unittest.TestCase):
         total_changes['hydro'] = ['foo', 'bar']
         total_changes['boxturtle'] = ['baz']
         total_changes['C'] = []
-        expect = '# Changes:\n'\
-                 '## Boxturtle Changes:\n'\
+        expect = 'Changes:\n'\
+                 '========\n'\
+                 'Boxturtle Changes:\n'\
+                 '------------------\n'\
                  '* *baz*\n\n'\
-                 '## Hydro Changes:\n'\
+                 'Hydro Changes:\n'\
+                 '--------------\n'\
                  '* *bar*\n'\
                  '* *foo*\n\n'
         got = gen_delta_msg(total_changes)


### PR DESCRIPTION
superflore currently generates commit messages that contain lines
starting with the markdown header indicator "#". However, commit message
lines that start with "#" are considered comments when amending a commit
and are removed unless the user remembers to quote them. Prevent these
lines from accidentally being removed by using the alternate form of
header indication: a line starting with "="-s or "-"-s underneath the
header text.