### PR TITLE
Include -native pkgs in list of OpenEmbedded platform dependencies (#230)

### DIFF
--- a/superflore/generators/bitbake/yocto_recipe.py
+++ b/superflore/generators/bitbake/yocto_recipe.py
@@ -322,7 +322,7 @@ class yoctoRecipe(object):
                 for res in results:
                     recipe = self.convert_to_oe_name(res, is_native)
                     dependencies.add(recipe)
-                    system_dependencies.add(self.convert_to_oe_name(res))
+                    system_dependencies.add(recipe)
                     yoctoRecipe.rosdep_cache[dep].add(res)
                     info('External dependency add: ' + recipe)
             except UnresolvedDependency:


### PR DESCRIPTION
ROS_SUPERFLORE_GENERATED_PLATFORM_PACKAGE_DEPENDENCIES is a list of
package names, not a list of recipes => add -native dependencies to it.