### PR TITLE
Allow the timestamp associated with the run to be overridden (#231)

### DIFF
--- a/superflore/generators/bitbake/run.py
+++ b/superflore/generators/bitbake/run.py
@@ -77,7 +77,9 @@ def main():
         parser.error('Invalid args! --only requires specifying --ros-distro')
     if not selected_targets:
         selected_targets = get_distros_by_status('active')
-    now = get_utcnow_timestamp_str()
+    now = os.getenv(
+        'SUPERFLORE_GENERATION_DATETIME',
+        get_utcnow_timestamp_str())
     repo_org = 'ros'
     repo_name = 'meta-ros'
     if args.upstream_repo:

--- a/superflore/generators/bitbake/yocto_recipe.py
+++ b/superflore/generators/bitbake/yocto_recipe.py
@@ -520,11 +520,11 @@ class yoctoRecipe(object):
                     '\n#\n# Copyright ' + strftime("%Y", gmtime())
                     + ' Open Source Robotics Foundation\n\n')
                 datetime_file.write(
-                    '\n# The start time, in UTC, of the last superflore run '
-                    + 'that resulted in a change to the generated files. The '
-                    + 'date portion is used as\n# the third version field of '
-                    + 'ROS_DISTRO_METADATA_VERSION prior to the first release'
-                    + ' of a ROS_DISTRO.\n')
+                    '\n# The time, in UTC, associated with the last superflore'
+                    + ' run that resulted in a change to the generated files.'
+                    + ' The date portion is\n# used as the third version field'
+                    + ' of ROS_DISTRO_METADATA_VERSION prior to the first'
+                    + ' release of a ROS_DISTRO.\n')
                 datetime_file.write(
                     'ROS_SUPERFLORE_GENERATION_DATETIME = "{}"\n'.format(now))
                 ok('Wrote {0}'.format(datetime_path))

--- a/superflore/generators/ebuild/overlay_instance.py
+++ b/superflore/generators/ebuild/overlay_instance.py
@@ -43,7 +43,10 @@ class RosOverlay(object):
             commit_msg = 'regenerate ros-{1}, {0}'
         else:
             commit_msg = 'rosdistro sync, {0}'
-        commit_msg = commit_msg.format(time.ctime(), distro)
+        timestamp = os.getenv(
+            'SUPERFLORE_GENERATION_DATETIME',
+            time.ctime())
+        commit_msg = commit_msg.format(timestamp, distro)
         self.repo.git.commit(m='{0}'.format(commit_msg))
 
     def regenerate_manifests(
@@ -76,5 +79,8 @@ class RosOverlay(object):
 
     def pull_request(self, message, overlay=None, title=''):
         if not title:
-            title = 'rosdistro sync, {0}'.format(time.ctime())
+            timestamp = os.getenv(
+                'SUPERFLORE_GENERATION_DATETIME',
+                time.ctime())
+            title = 'rosdistro sync, {0}'.format(timestamp)
         self.repo.pull_request(message, title)


### PR DESCRIPTION
ROS_SUPERFLORE_GENERATED_PLATFORM_PACKAGE_DEPENDENCIES is a list of
package names, not a list of recipes => add -native dependencies to it.