### PR TITLE
 Use "ebuild"/"recipe" instead of "installer" (#226)

### DIFF
--- a/superflore/generators/bitbake/gen_packages.py
+++ b/superflore/generators/bitbake/gen_packages.py
@@ -68,7 +68,7 @@ def regenerate_pkg(
         idx_version = existing.rfind('_') + len('_')
         previous_version = existing[idx_version:].rstrip('.bb')
     try:
-        current = oe_installer(
+        current = oe_recipe(
             distro, pkg, tar_dir, md5_cache, sha256_cache, skip_keys
         )
     except InvalidPackage as e:
@@ -76,7 +76,7 @@ def regenerate_pkg(
         yoctoRecipe.not_generated_recipes.add(pkg)
         return None, [], None
     except Exception as e:
-        err('Failed generating installer for {}! {}'.format(pkg, str(e)))
+        err('Failed generating recipe for {}! {}'.format(pkg, str(e)))
         yoctoRecipe.not_generated_recipes.add(pkg)
         return None, [], None
     try:
@@ -96,7 +96,7 @@ def regenerate_pkg(
             component_name
         )
     )
-    success_msg = 'Successfully generated installer for package'
+    success_msg = 'Successfully generated recipe for package'
     ok('{0} \'{1}\'.'.format(success_msg, pkg))
     recipe_file_name = '{0}/generated-recipes-{1}/{2}/{3}_{4}.bb'.format(
         repo_dir,
@@ -180,7 +180,7 @@ def _gen_recipe_for_package(
     return pkg_recipe
 
 
-class oe_installer(object):
+class oe_recipe(object):
     def __init__(
         self, distro, pkg_name, tar_dir, md5_cache, sha256_cache, skip_keys
     ):

--- a/superflore/generators/ebuild/gen_packages.py
+++ b/superflore/generators/ebuild/gen_packages.py
@@ -75,12 +75,12 @@ def regenerate_pkg(overlay, pkg, distro, preserve_existing=False):
         )
         overlay.repo.remove_file(manifest_file)
     try:
-        current = gentoo_installer(distro, pkg, has_patches)
+        current = gentoo_ebuild(distro, pkg, has_patches)
         current.ebuild.name = pkg
         current.ebuild.patches = patches
         current.ebuild.is_ros2 = is_ros2
     except Exception as e:
-        err('Failed to generate installer for package {}!'.format(pkg))
+        err('Failed to generate ebuild for package {}!'.format(pkg))
         raise e
     try:
         ebuild_text = current.ebuild_text()
@@ -98,7 +98,7 @@ def regenerate_pkg(overlay, pkg, distro, preserve_existing=False):
     make_dir(
         "{}/ros-{}/{}".format(overlay.repo.repo_dir, distro.name, pkg)
     )
-    success_msg = 'Successfully generated installer for package'
+    success_msg = 'Successfully generated ebuild for package'
     ok('{0} \'{1}\'.'.format(success_msg, pkg))
 
     try:
@@ -189,7 +189,7 @@ def _gen_ebuild_for_package(
     return pkg_ebuild
 
 
-class gentoo_installer(object):
+class gentoo_ebuild(object):
     def __init__(self, distro, pkg_name, has_patches=False):
         pkg = distro.release_packages[pkg_name]
         repo = distro.repositories[pkg.repository_name].release_repository


### PR DESCRIPTION
Use the terms "ebuild" and "recipe" instead of "installer" except in
names that are meant to refer to both.
