### PR TITLE
repo_instance: initialize gh_upstream only when creating pull request (#246)

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,12 @@ Dependencies:
 
 Instructions:
 -------------
-Generate an [OAuth token](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/) for this application.
+To automatically create a pull-request, you need to generate an [OAuth token](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/) for this application.
 
 After you have created the token, place it in the
 environment variable `SUPERFLORE_GITHUB_TOKEN`.
+
+If you're running it with `--dry-run` enabled, then `SUPERFLORE_GITHUB_TOKEN` isn't needed.
 
 Then install and run the application.
 

--- a/superflore/exceptions.py
+++ b/superflore/exceptions.py
@@ -29,8 +29,10 @@ class NoPkgXml(Exception):
 
 
 class NoGitHubAuthToken(Exception):
-    def __init__(self, message):
-        self.message = message
+    def __init__(self):
+        self.message = 'Please create an OAuth token for Superflore, ' \
+            'and place the string in the environment variable ' \
+            'SUPERFLORE_GITHUB_TOKEN'
 
 
 class UnknownBuildType(Exception):

--- a/superflore/generators/bitbake/run.py
+++ b/superflore/generators/bitbake/run.py
@@ -17,6 +17,7 @@ import sys
 
 from rosinstall_generator.distro import get_distro
 from superflore.CacheManager import CacheManager
+from superflore.exceptions import NoGitHubAuthToken
 from superflore.generate_installers import generate_installers
 from superflore.generators.bitbake.gen_packages import regenerate_pkg
 from superflore.generators.bitbake.ros_meta import RosMeta
@@ -54,6 +55,9 @@ def main():
     pr_comment = args.pr_comment
     skip_keys = set(args.skip_keys) if args.skip_keys else set()
     selected_targets = None
+    if not args.dry_run:
+        if 'SUPERFLORE_GITHUB_TOKEN' not in os.environ:
+            raise NoGitHubAuthToken()
     if args.pr_only:
         if args.dry_run:
             parser.error('Invalid args! cannot dry-run and file PR')

--- a/superflore/generators/ebuild/run.py
+++ b/superflore/generators/ebuild/run.py
@@ -16,6 +16,7 @@ import os
 import sys
 
 from rosinstall_generator.distro import get_distro
+from superflore.exceptions import NoGitHubAuthToken
 from superflore.generate_installers import generate_installers
 from superflore.generators.ebuild.gen_packages import regenerate_pkg
 from superflore.generators.ebuild.overlay_instance import RosOverlay
@@ -44,6 +45,9 @@ def main():
     pr_comment = args.pr_comment
     skip_keys = args.skip_keys or []
     selected_targets = None
+    if not args.dry_run:
+        if 'SUPERFLORE_GITHUB_TOKEN' not in os.environ:
+            raise NoGitHubAuthToken()
     if args.pr_only:
         if args.dry_run:
             parser.error('Invalid args! cannot dry-run and file PR')

--- a/superflore/repo_instance.py
+++ b/superflore/repo_instance.py
@@ -18,7 +18,6 @@ import shutil
 from git import Repo
 from git.exc import GitCommandError as GitGotGot
 from github import Github
-from superflore.exceptions import NoGitHubAuthToken
 from superflore.utils import err
 from superflore.utils import info
 from superflore.utils import ok
@@ -43,19 +42,6 @@ class RepoInstance(object):
         else:
             self.repo = Repo(repo_dir)
         self.git = self.repo.git
-        if 'SUPERFLORE_GITHUB_TOKEN' not in os.environ:
-            raise NoGitHubAuthToken(
-                'Please create an OAuth token for Superflore, and place '
-                'the string in the environment variable '
-                'SUPERFLORE_GITHUB_TOKEN'
-            )
-        self.github = Github(os.environ['SUPERFLORE_GITHUB_TOKEN'])
-        self.gh_user = self.github.get_user()
-        self.gh_upstream = self.github.get_repo(
-            '%s/%s' % (
-                repo_owner, repo_name
-            )
-        )
 
     def clone(self, branch=None):
         shutil.rmtree(self.repo_dir)
@@ -108,6 +94,13 @@ class RepoInstance(object):
 
     def pull_request(self, message, title, branch='master', remote='origin'):
         info('Forking repository if a fork does not exist...')
+        self.github = Github(os.environ['SUPERFLORE_GITHUB_TOKEN'])
+        self.gh_user = self.github.get_user()
+        self.gh_upstream = self.github.get_repo(
+            '%s/%s' % (
+                self.repo_owner, self.repo_name
+            )
+        )
         # TODO(allenh1): Don't fork if you're authorized for repo
         forked_repo = self.gh_user.create_fork(self.gh_upstream)
         info('Pushing changes to fork...')


### PR DESCRIPTION
* to be able to generate the recipes locally without OAuth set

* currently it needs OAuth even when generating just locally and fails with:

  meta-ros$ sh scripts/ros-generate-recipes.sh crystal
  >>>> "crystal" distro detected...
  args.output_repository_path: '.'
  Traceback (most recent call last):
    File "/usr/local/bin/superflore-gen-oe-recipes", line 11, in <module>
      load_entry_point('superflore==0.2.1', 'console_scripts', 'superflore-gen-oe-recipes')()
    File "/usr/local/lib/python3.6/dist-packages/superflore-0.2.1-py3.6.egg/superflore/generators/bitbake/run.py", line 98, in main
    File "/usr/local/lib/python3.6/dist-packages/superflore-0.2.1-py3.6.egg/superflore/generators/bitbake/ros_meta.py", line 24, in __init__
    File "/usr/local/lib/python3.6/dist-packages/superflore-0.2.1-py3.6.egg/superflore/repo_instance.py", line 48, in __init__
  superflore.exceptions.NoGitHubAuthToken: Please create an OAuth token for Superflore, and place the string in the environment variable SUPERFLORE_GITHUB_TOKEN

Signed-off-by: Martin Jansa <martin.jansa@lge.com>