### PR TITLE
generators: add --no-branch option to prevent creating new local branch (#248)

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Gentoo Usage:
 ```
 $ superflore-gen-ebuilds --help
 usage: Deploy ROS packages into Gentoo Linux [-h] [--ros-distro ROS_DISTRO]
-                                             [--all] [--dry-run] [--pr-only]
+                                             [--all] [--dry-run] [--pr-only] [--no-branch]
                                              [--output-repository-path OUTPUT_REPOSITORY_PATH]
                                              [--only ONLY [ONLY ...]]
 
@@ -48,6 +48,7 @@ optional arguments:
   --all                 regenerate all packages in all distros
   --dry-run             run without filing a PR to remote
   --pr-only             ONLY file a PR to remote
+  --no-branch           Do not create a new branch automatically
   --output-repository-path OUTPUT_REPOSITORY_PATH
                         location of the Git repo
   --only ONLY [ONLY ...]
@@ -140,7 +141,7 @@ should be followed to generate the OpenEmbedded recipes for `meta-ros`.
 $ superflore-gen-oe-recipes --help
 usage: Deploy ROS packages into OpenEmbedded Linux [-h]
                                                    [--ros-distro ROS_DISTRO]
-                                                   [--dry-run] [--pr-only]
+                                                   [--dry-run] [--pr-only] [--no-branch]
                                                    [--output-repository-path OUTPUT_REPOSITORY_PATH]
                                                    [--only ONLY [ONLY ...]]
                                                    [--pr-comment PR_COMMENT]
@@ -155,6 +156,7 @@ optional arguments:
                         regenerate packages for the specified distro
   --dry-run             run without filing a PR to remote
   --pr-only             ONLY file a PR to remote
+  --no-branch           Do not create a new branch automatically
   --output-repository-path OUTPUT_REPOSITORY_PATH
                         location of the Git repo
   --only ONLY [ONLY ...]

--- a/superflore/generators/bitbake/ros_meta.py
+++ b/superflore/generators/bitbake/ros_meta.py
@@ -18,13 +18,15 @@ from superflore.utils import info
 
 class RosMeta(object):
     def __init__(
-        self, dir, do_clone, branch, org='ros', repo='meta-ros', from_branch=''
+        self, dir, do_clone, branch, org='ros', repo='meta-ros',
+        from_branch='', branch_name=''
     ):
         self.repo = RepoInstance(
             org, repo, dir, do_clone, from_branch=from_branch)
         self.branch_name = branch
-        info('Creating new branch {0}...'.format(self.branch_name))
-        self.repo.create_branch(self.branch_name)
+        if branch:
+            info('Creating new branch {0}...'.format(self.branch_name))
+            self.repo.create_branch(self.branch_name)
 
     def clean_ros_recipe_dirs(self, distro=None):
         if distro:
@@ -48,7 +50,10 @@ class RosMeta(object):
         if self.repo.git.status('--porcelain') == '':
             info('Nothing changed; no commit done')
         else:
-            info('Committing to branch {0}...'.format(self.branch_name))
+            if self.branch_name:
+                info('Committing to branch {0}...'.format(self.branch_name))
+            else:
+                info('Committing to current branch')
             self.repo.git.commit(m=commit_msg)
 
     def pull_request(self, message, distro=None, title=''):

--- a/superflore/generators/bitbake/run.py
+++ b/superflore/generators/bitbake/run.py
@@ -93,7 +93,8 @@ def main():
         overlay = RosMeta(
             _repo,
             not args.output_repository_path,
-            branch='superflore/{}'.format(now),
+            branch=(('superflore/{}'.format(now)) if not args.no_branch
+                    else None),
             org=repo_org,
             repo=repo_name,
             from_branch=args.upstream_branch,

--- a/superflore/generators/ebuild/overlay_instance.py
+++ b/superflore/generators/ebuild/overlay_instance.py
@@ -24,14 +24,18 @@ from superflore.utils import rand_ascii_str
 
 class RosOverlay(object):
     def __init__(
-        self, repo_dir, do_clone, org='ros', repo='ros-overlay', from_branch=''
+        self, repo_dir, do_clone, org='ros', repo='ros-overlay',
+        from_branch='', new_branch=True
     ):
         self.repo = RepoInstance(
             org, repo, repo_dir=repo_dir, do_clone=do_clone,
             from_branch=from_branch)
-        self.branch_name = 'gentoo-bot-%s' % rand_ascii_str()
-        info('Creating new branch {0}...'.format(self.branch_name))
-        self.repo.create_branch(self.branch_name)
+        if new_branch:
+            self.branch_name = 'gentoo-bot-%s' % rand_ascii_str()
+            info('Creating new branch {0}...'.format(self.branch_name))
+            self.repo.create_branch(self.branch_name)
+        else:
+            self.branch_name = None
 
     def commit_changes(self, distro):
         info('Adding changes...')
@@ -39,7 +43,10 @@ class RosOverlay(object):
         if self.repo.git.status('--porcelain') == '':
             info('Nothing changed; no commit done')
         else:
-            info('Committing to branch {0}...'.format(self.branch_name))
+            if self.branch_name:
+                info('Committing to branch {0}...'.format(self.branch_name))
+            else:
+                info('Committing to current branch')
             if distro == 'all':
                 commit_msg = 'regenerate all distros, {0}'
             elif distro:

--- a/superflore/generators/ebuild/run.py
+++ b/superflore/generators/ebuild/run.py
@@ -85,6 +85,7 @@ def main():
             org=repo_org,
             repo=repo_name,
             from_branch=args.upstream_branch,
+            new_branch=(not args.no_branch),
         )
         if not preserve_existing and not args.only:
             pr_comment = pr_comment or (

--- a/superflore/parser.py
+++ b/superflore/parser.py
@@ -41,6 +41,11 @@ def get_parser(tool_tip, is_generator=True, exclude_all=False):
             action='store_true'
         )
         parser.add_argument(
+            '--no-branch',
+            help='Do not create a new branch automatically',
+            action='store_true'
+        )
+        parser.add_argument(
             '--output-repository-path',
             help='location of the Git repo',
             type=str


### PR DESCRIPTION
* useful when regenerating the files locally by hand without planing to submit
  PR with the changes or when some other tool will do additional
  integration before doing the PR (like we plan to do with meta-ros)

Signed-off-by: Martin Jansa <martin.jansa@lge.com>