### PR TITLE
yocto_recipe.py: don't create cache.yaml and cache.diffme (#252)

### DIFF
--- a/superflore/generators/bitbake/ros_meta.py
+++ b/superflore/generators/bitbake/ros_meta.py
@@ -41,7 +41,6 @@ class RosMeta(object):
         info('Adding changes...')
         self.repo.git.add('generated-recipes-{0}'.format(distro))
         self.repo.git.add('conf/ros-distro/include/{0}/*.inc'.format(distro))
-        self.repo.git.add('files/{0}/cache.*'.format(distro))
         self.repo.git.add('files/{0}/rosdep-resolve.yaml'.format(distro))
         self.repo.git.add(
             'files/{0}/newer-platform-components.list'.format(distro))
@@ -68,7 +67,6 @@ class RosMeta(object):
         return '\n'.join([
             sep, self.repo.git.status('--porcelain'), sep,
             self.repo.git.diff('conf'), sep, self.repo.git.diff(
-                'files/*/cache.diffme',
                 'files/*/newer-platform-components.list',
                 'files/*/rosdep-resolve.yaml'
             ),

--- a/superflore/generators/bitbake/run.py
+++ b/superflore/generators/bitbake/run.py
@@ -153,7 +153,6 @@ def main():
                     distro.release_platforms, skip_keys)
                 yoctoRecipe.generate_superflore_datetime_inc(
                     _repo, args.ros_distro, now)
-                yoctoRecipe.generate_distro_cache(_repo, args.ros_distro)
                 yoctoRecipe.generate_rosdep_resolve(_repo, args.ros_distro)
                 yoctoRecipe.generate_newer_platform_components(
                     _repo, args.ros_distro)
@@ -201,7 +200,6 @@ def main():
                     distro.release_platforms, skip_keys)
                 yoctoRecipe.generate_superflore_datetime_inc(
                     _repo, args.ros_distro, now)
-                yoctoRecipe.generate_distro_cache(_repo, args.ros_distro)
                 yoctoRecipe.generate_rosdep_resolve(_repo, args.ros_distro)
                 yoctoRecipe.generate_newer_platform_components(
                     _repo, args.ros_distro)

--- a/superflore/generators/bitbake/yocto_recipe.py
+++ b/superflore/generators/bitbake/yocto_recipe.py
@@ -32,7 +32,6 @@ import tarfile
 from time import gmtime, strftime
 from urllib.request import urlretrieve
 
-from rosdistro import get_distribution_cache_string, get_index, get_index_url
 from superflore.exceptions import NoPkgXml
 from superflore.exceptions import UnresolvedDependency
 from superflore.generators.bitbake.oe_query import OpenEmbeddedLayersDB
@@ -654,53 +653,6 @@ class yoctoRecipe(object):
                 ok('Wrote {0}'.format(conf_path))
         except OSError as e:
             err('Failed to write conf {} to disk! {}'.format(conf_path, e))
-            raise e
-
-    @staticmethod
-    def generate_distro_cache(basepath, distro, skip_keys=[]):
-        distro_cache_dir = '{0}/files/{1}/'.format(basepath, distro)
-        distro_cache_path = '{0}cache.yaml'.format(distro_cache_dir)
-        try:
-            index = get_index(get_index_url())
-            yaml_str = get_distribution_cache_string(index, distro)
-            make_dir(distro_cache_dir)
-            with open(distro_cache_path, 'w') as distro_cache_file:
-                distro_cache_file.write('# {}/cache.yaml\n'.format(distro))
-                distro_cache_file.write(yaml_str)
-                ok('Wrote {0}'.format(distro_cache_path))
-        except OSError as e:
-            err('Failed to write distro cache {} to disk! {}'.format(
-                distro_cache_path, e))
-            raise e
-        # Generate a diff'able cache file
-        distro_cache_diff_path = '{}cache.diffme'.format(distro_cache_dir)
-        try:
-            def replace_all_patterns(d, text):
-                for k, v in d.items():
-                    text = re.sub(k, v, text, flags=re.M)
-                return text
-            replacement_table = {
-                r"{([^ }][^ }]*)}": r'[[\1]]',
-                r"{": r"{\n",
-                r"}": r"\n}",
-                r"\[\[": r"{",
-                r"\]\]": r"}",
-                r", ": r",\n",
-                r"^    ": r"-----\n",
-                r"<version>[^<]*</version>": r"",
-                r"><": r">\n<",
-                r"^  ": r"-----\n",
-                r"^(source_repo_package_xmls:)": r"-----\n\1",
-            }
-            with open(distro_cache_diff_path, 'w') as distro_cache_diff_file:
-                distro_cache_diff_file.write(
-                    '# {}/cache.diffme\n'.format(distro))
-                yaml_str = replace_all_patterns(replacement_table, yaml_str)
-                distro_cache_diff_file.write(yaml_str)
-                ok('Wrote {0}'.format(distro_cache_diff_path))
-        except OSError as e:
-            err('Failed to write diffme distro cache {} to disk! {}'.format(
-                distro_cache_diff_path, e))
             raise e
 
     @staticmethod


### PR DESCRIPTION
* ros-generate-cache.sh already does that and superflore then just
  generates recipes from cache.yaml file updated by
  ros-generate-cache.sh
* fixes: https://github.com/ros-infrastructure/superflore/issues/252
* needs: https://github.com/ros/meta-ros/pull/643

Signed-off-by: Martin Jansa <martin.jansa@lge.com>