### PR TITLE
yocto_recipe.py: bump ROS_SUPERFLORE_GENERATION_SCHEME

### DIFF
--- a/superflore/generators/bitbake/yocto_recipe.py
+++ b/superflore/generators/bitbake/yocto_recipe.py
@@ -558,7 +558,7 @@ class yoctoRecipe(object):
                 conf_file.write(
                     '\nROS_SUPERFLORE_PROGRAM_VERSION = "{}"\n'
                     .format(get_superflore_version()))
-                conf_file.write('ROS_SUPERFLORE_GENERATION_SCHEME = "1"\n')
+                conf_file.write('ROS_SUPERFLORE_GENERATION_SCHEME = "2"\n')
                 ros_version = yoctoRecipe._get_ros_version(distro)
                 conf_file.write(
                     '\nROS_DISTRO_TYPE = "ros{}"\n'.format(ros_version))

--- a/superflore/generators/bitbake/yocto_recipe.py
+++ b/superflore/generators/bitbake/yocto_recipe.py
@@ -713,7 +713,8 @@ class yoctoRecipe(object):
             make_dir(change_summary_dir)
             with open(change_summary_path, 'w') as change_summary_file:
                 change_summary_file.write(
-                    '{}/superflore-change-summary.txt\n'.format(distro))
+                    '{}/generated/superflore-change-summary.txt\n'.format(
+                        distro))
                 change_summary_file.write(change_summary)
                 ok('Wrote {0}'.format(change_summary_path))
         except OSError as e:


### PR DESCRIPTION
* superflore now with changes from:
  https://github.com/ros-infrastructure/superflore/pull/256
  generates the OE recipes according to ROS_SUPERFLORE_GENERATION_SCHEME 2

Signed-off-by: Martin Jansa <martin.jansa@lge.com>