### PR TITLE
superflore-gen-oe-recipes: Delete all generated files when regenerating all recipes

### DIFF
--- a/superflore/generators/bitbake/ros_meta.py
+++ b/superflore/generators/bitbake/ros_meta.py
@@ -29,16 +29,23 @@ class RosMeta(object):
             info('Creating new branch {0}...'.format(self.branch_name))
             self.repo.create_branch(self.branch_name)
 
-    def clean_ros_recipe_dirs(self, distro=None):
-        if distro:
-            info(
-                'Cleaning up meta-ros{}-{}/generated-recipes directory...'
-                .format(yoctoRecipe._get_ros_version(distro), distro))
-            self.repo.git.rm('-rf', 'meta-ros{}-{}/generated-recipes'.format(
-                yoctoRecipe._get_ros_version(distro), distro))
-        else:
-            info('Cleaning up generated-recipes directories...')
-            self.repo.git.rm('-rf', 'generated-recipes')
+    def clean_ros_recipe_dirs(self, distro):
+        # superflore-change-summary.txt is no longer being generated since:
+        # https://github.com/ros-infrastructure/superflore/pull/273
+        # but remove it here to make sure it gets deleted when new distro
+        # release is being generated
+        files = 'meta-ros{0}-{1}/generated-recipes '\
+                'meta-ros{0}-{1}/conf/ros-distro/include/{1}/generated '\
+                'meta-ros{0}-{1}/files/{1}/generated/'\
+                'newer-platform-components.list '\
+                'meta-ros{0}-{1}/files/{1}/generated/rosdep-resolve.yaml '\
+                'meta-ros{0}-{1}/files/{1}/generated/'\
+                'superflore-change-summary.txt '.format(
+                    yoctoRecipe._get_ros_version(distro), distro)
+        info(
+            'Cleaning up:\n{0}'
+            .format(files))
+        self.repo.git.rm('-rf', '--ignore-unmatch', files)
 
     def commit_changes(self, distro, commit_msg):
         info('Commit changes...')

--- a/superflore/generators/bitbake/run.py
+++ b/superflore/generators/bitbake/run.py
@@ -158,6 +158,7 @@ def main():
                 ok('Successfully synchronized repositories!')
                 sys.exit(0)
 
+            overlay.clean_ros_recipe_dirs(args.ros_distro)
             for adistro in selected_targets:
                 yoctoRecipe.reset()
                 distro = get_distro(adistro)


### PR DESCRIPTION
* the overlay.repo.remove_file(existing, True) call in bitbake/gen_packages.py
  works fine, but only when the new recipe is being generated in the same directory
  as the previous version:
  existing = glob.glob('{}_*.bb'.format(prefix))
  where prefix is:
  prefix = '{0}/meta-ros{1}-{2}/generated-recipes/{3}/{4}'
  which will result in multiple recipes for the same package when the
  package is moved to different prefix like pcl-conversions did for
  dashing and eloquent:
```
  meta-ros$ find . -name pcl-conversions\*bb
  ./meta-ros2-eloquent/generated-recipes/perception-pcl/pcl-conversions_2.1.0-1.bb
  ./meta-ros2-eloquent/generated-recipes/pcl-conversions/pcl-conversions_2.0.0-1.bb
  ./meta-ros1-melodic/generated-recipes/perception-pcl/pcl-conversions_1.7.0-2.bb
  ./meta-ros2-crystal/generated-recipes/pcl-conversions/pcl-conversions_2.0.0.bb
  ./meta-ros2-dashing/generated-recipes/perception-pcl/pcl-conversions_2.0.0-1.bb
  ./meta-ros2-dashing/generated-recipes/pcl-conversions/pcl-conversions_2.0.0-1.bb
```
  and especially for dashing where the version is identical it's
  undeterministic which recipe bitbake will use. And the recipe wasn't
  just moved to different directory, it's quite different:
```
diff ./meta-ros2-dashing/generated-recipes/perception-pcl/pcl-conversions_2.0.0-1.bb ./meta-ros2-dashing/generated-recipes/pcl-conversions/pcl-conversions_2.0.0-1.bb
9c9
< AUTHOR = "Paul Bovbel <paul@bovbel.com>"
---
> AUTHOR = "Chris Lalancette <clalancette@openrobotics.org>"
14c14
< LIC_FILES_CHKSUM = "file://package.xml;beginline=16;endline=16;md5=d566ef916e9dedc494f5f793a6690ba5"
---
> LIC_FILES_CHKSUM = "file://package.xml;beginline=12;endline=12;md5=d566ef916e9dedc494f5f793a6690ba5"
16c16
< ROS_CN = "perception_pcl"
---
> ROS_CN = "pcl_conversions"
19a20
>     builtin-interfaces \
21d21
<     message-filters \
23,24d22
<     pcl-msgs \
<     rclcpp \
33a32
>     builtin-interfaces \
35d33
<     message-filters \
37,38d34
<     pcl-msgs \
<     rclcpp \
46,47d41
<     libeigen \
<     message-filters \
49,52d42
<     pcl-msgs \
<     rclcpp \
<     sensor-msgs \
<     std-msgs \
67c57
< # matches with: https://github.com/ros2-gbp/perception_pcl-release/archive/release/dashing/pcl_conversions/2.0.0-1.tar.gz
---
> # matches with: https://github.com/ros2-gbp/pcl_conversions-release/archive/release/dashing/pcl_conversions/2.0.0-1.tar.gz
69,70c59,60
< SRC_URI = "git://github.com/ros2-gbp/perception_pcl-release;${ROS_BRANCH};protocol=https"
< SRCREV = "0f550985da8bd73fd7451350c63e1ce96e78c955"
---
> SRC_URI = "git://github.com/ros2-gbp/pcl_conversions-release;${ROS_BRANCH};protocol=https"
> SRCREV = "8d0d0ef7d5d253f11fbf52388d64fad59e46377a"
```
* grep in the current build logs shows that the "older"
  meta-ros2-dashing/generated-recipes/pcl-conversions/pcl-conversions_2.0.0-1.bb
  was currently being used in dashing instead of "newer"
  meta-ros2-dashing/generated-recipes/perception-pcl/pcl-conversions_2.0.0-1.bb

* corresponding rosdistro change for dashing:
  https://github.com/ros/rosdistro/commit/19b06c44df69f9bf44dd7ab1b74236e9e386c848
  and eloquent:
  https://github.com/ros/rosdistro/commit/67c3ef53979ea8d85254bdfc427b142eda69fb57

Signed-off-by: Martin Jansa <martin.jansa@lge.com>