### PR TITLE
yocto_recipe.py: Use sensible default for <build_type> when not ROS 1

### DIFF
--- a/superflore/generators/bitbake/yocto_recipe.py
+++ b/superflore/generators/bitbake/yocto_recipe.py
@@ -95,7 +95,8 @@ class yoctoRecipe(object):
             self.description = ''
             self.license = None
             self.homepage = None
-            self.build_type = 'catkin'
+            self.build_type = 'catkin' if \
+                yoctoRecipe._get_ros_version(distro) == 1 else 'ament_cmake'
             self.maintainer = "OSRF"
         self.depends = set()
         self.depends_external = set()


### PR DESCRIPTION
…rsion isn't 1

Signed-off-by: Martin Jansa <martin.jansa@lge.com>