### PR TITLE
bitbake:  Drop generation of superfore-change-summary.txt; fix exception message

### DIFF
--- a/superflore/generators/bitbake/ros_meta.py
+++ b/superflore/generators/bitbake/ros_meta.py
@@ -41,21 +41,7 @@ class RosMeta(object):
             self.repo.git.rm('-rf', 'generated-recipes')
 
     def commit_changes(self, distro, commit_msg):
-        info('Adding changes...')
-        self.repo.git.add('meta-ros{0}-{1}/generated-recipes'.format(
-            yoctoRecipe._get_ros_version(distro), distro))
-        self.repo.git.add('meta-ros{0}-{1}/conf/ros-distro/include/{1}/'
-                          'generated/*.inc'.format(
-                              yoctoRecipe._get_ros_version(distro), distro))
-        self.repo.git.add('meta-ros{0}-{1}/files/{1}/generated/'
-                          'rosdep-resolve.yaml'.format(
-                              yoctoRecipe._get_ros_version(distro), distro))
-        self.repo.git.add('meta-ros{0}-{1}/files/{1}/generated/'
-                          'newer-platform-components.list'.format(
-                              yoctoRecipe._get_ros_version(distro), distro))
-        self.repo.git.add('meta-ros{0}-{1}/files/{1}/generated/'
-                          'superflore-change-summary.txt'.format(
-                              yoctoRecipe._get_ros_version(distro), distro))
+        info('Commit changes...')
         if self.repo.git.status('--porcelain') == '':
             info('Nothing changed; no commit done')
         else:
@@ -71,20 +57,34 @@ class RosMeta(object):
     def get_file_revision_logs(self, *file_path):
         return self.repo.git.log('--oneline', '--', *file_path)
 
-    def get_change_summary(self, distro):
+    def add_generated_files(self, distro):
+        info('Adding changes...')
         self.repo.git.add('meta-ros{0}-{1}/generated-recipes'.format(
             yoctoRecipe._get_ros_version(distro), distro))
+        self.repo.git.add('meta-ros{0}-{1}/conf/ros-distro/include/{1}/'
+                          'generated/*.inc'.format(
+                              yoctoRecipe._get_ros_version(distro), distro))
+        self.repo.git.add('meta-ros{0}-{1}/files/{1}/generated/'
+                          'rosdep-resolve.yaml'.format(
+                              yoctoRecipe._get_ros_version(distro), distro))
+        self.repo.git.add('meta-ros{0}-{1}/files/{1}/generated/'
+                          'newer-platform-components.list'.format(
+                              yoctoRecipe._get_ros_version(distro), distro))
+
+    def get_change_summary(self, distro):
         sep = '-' * 5
         return '\n'.join([
             sep,
             self.repo.git.status('--porcelain'),
             sep,
             self.repo.git.diff(
+                'HEAD',
                 'meta-ros{0}-{1}/conf/ros-distro/include/{1}/'
                 'generated/*.inc'.format(
                     yoctoRecipe._get_ros_version(distro), distro)),
             sep,
             self.repo.git.diff(
+                'HEAD',
                 'meta-ros{0}-{1}/files/{1}/generated/'
                 'newer-platform-components.list'.format(
                     yoctoRecipe._get_ros_version(distro), distro),

--- a/superflore/generators/bitbake/run.py
+++ b/superflore/generators/bitbake/run.py
@@ -186,9 +186,7 @@ def main():
                 yoctoRecipe.generate_rosdep_resolve(_repo, args.ros_distro)
                 yoctoRecipe.generate_newer_platform_components(
                     _repo, args.ros_distro)
-                yoctoRecipe.generate_superflore_change_summary(
-                    _repo, args.ros_distro,
-                    overlay.get_change_summary(args.ros_distro))
+                overlay.add_generated_files(args.ros_distro)
 
         num_changes = 0
         for distro_name in total_changes:

--- a/superflore/generators/bitbake/yocto_recipe.py
+++ b/superflore/generators/bitbake/yocto_recipe.py
@@ -703,25 +703,6 @@ class yoctoRecipe(object):
             raise e
 
     @staticmethod
-    def generate_superflore_change_summary(basepath, distro, change_summary):
-        change_summary_dir = '{0}/meta-ros{1}-{2}/files/{2}/generated/'.format(
-            basepath, yoctoRecipe._get_ros_version(distro), distro)
-        change_summary_path = '{0}superflore-change-summary.txt'.format(
-            change_summary_dir)
-        try:
-            make_dir(change_summary_dir)
-            with open(change_summary_path, 'w') as change_summary_file:
-                change_summary_file.write(
-                    '{}/generated/superflore-change-summary.txt\n'.format(
-                        distro))
-                change_summary_file.write(change_summary)
-                ok('Wrote {0}'.format(change_summary_path))
-        except OSError as e:
-            err('Failed to write change summary {} to disk! {}'.format(
-                change_summary_path, e))
-            raise e
-
-    @staticmethod
     def generate_newer_platform_components(basepath, distro):
         newer_sys_comps_dir = '{0}/meta-ros{1}-{2}/files/{2}/' \
                               'generated/'.format(

--- a/superflore/generators/bitbake/yocto_recipe.py
+++ b/superflore/generators/bitbake/yocto_recipe.py
@@ -754,7 +754,7 @@ class yoctoRecipe(object):
                 newer_sys_comps_file.write(txt_output)
                 ok('Wrote {0}'.format(newer_sys_comps_path))
         except (OSError, RuntimeError) as e:
-            err('Failed to write change summary {} to disk! {}'.format(
+            err('Failed to write {0} to disk! {1}'.format(
                 newer_sys_comps_path, e))
             raise e
 


### PR DESCRIPTION
* Now that there are two commits for every ROS distro release (one generated by ros-generate-cache and the other by superflore via ros-generate-recipes), having superflore attempt to generate a file that summarizes the changes introduced by the new release no longer makes sense (and what's being produced currently is useless) => drop the generation of superflore-change-summary.txt.

* Resolves #274.