### PR TITLE
parser.py: Show program name in usage message instead of description

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,15 +38,16 @@ Gentoo Usage:
 ### Generating Gentoo Ebuilds
 ```
 $ superflore-gen-ebuilds -h
-usage: Deploy ROS packages into Gentoo Linux [-h] [--ros-distro ROS_DISTRO]
-                                             [--all] [--dry-run] [--pr-only]
-                                             [--no-branch]
-                                             [--output-repository-path OUTPUT_REPOSITORY_PATH]
-                                             [--only ONLY [ONLY ...]]
-                                             [--pr-comment PR_COMMENT]
-                                             [--upstream-repo UPSTREAM_REPO]
-                                             [--upstream-branch UPSTREAM_BRANCH]
-                                             [--skip-keys SKIP_KEYS [SKIP_KEYS ...]]
+usage: superflore-gen-ebuilds [-h] [--ros-distro ROS_DISTRO] [--all]
+                              [--dry-run] [--pr-only] [--no-branch]
+                              [--output-repository-path OUTPUT_REPOSITORY_PATH]
+                              [--only ONLY [ONLY ...]]
+                              [--pr-comment PR_COMMENT]
+                              [--upstream-repo UPSTREAM_REPO]
+                              [--upstream-branch UPSTREAM_BRANCH]
+                              [--skip-keys SKIP_KEYS [SKIP_KEYS ...]]
+
+Deploy ROS packages into Gentoo Linux
 
 optional arguments:
   -h, --help            show this help message and exit
@@ -74,11 +75,12 @@ optional arguments:
 ### Testing Gentoo Ebuilds
 ```
 $ superflore-check-ebuilds -h
-usage: Check if ROS packages are building for Gentoo Linux [-h]
-                                                           [--ros-distro ROS_DISTRO [ROS_DISTRO ...]]
-                                                           [--pkgs PKGS [PKGS ...]]
-                                                           [-f F] [-v]
-                                                           [--log-file LOG_FILE]
+usage: superflore-check-ebuilds [-h]
+                                [--ros-distro ROS_DISTRO [ROS_DISTRO ...]]
+                                [--pkgs PKGS [PKGS ...]] [-f F] [-v]
+                                [--log-file LOG_FILE]
+
+Check if ROS packages are building for Gentoo Linux
 
 optional arguments:
   -h, --help            show this help message and exit
@@ -146,16 +148,17 @@ should be followed to generate the OpenEmbedded recipes for `meta-ros`.
 
 ```
 $ superflore-gen-oe-recipes -h
-usage: Deploy ROS packages into OpenEmbedded Linux [-h] --ros-distro
-                                                   ROS_DISTRO --dry-run
-                                                   [--pr-only] [--no-branch]
-                                                   [--output-repository-path OUTPUT_REPOSITORY_PATH]
-                                                   [--only ONLY [ONLY ...]]
-                                                   [--pr-comment PR_COMMENT]
-                                                   [--upstream-repo UPSTREAM_REPO]
-                                                   [--upstream-branch UPSTREAM_BRANCH]
-                                                   [--skip-keys SKIP_KEYS [SKIP_KEYS ...]]
-                                                   [--tar-archive-dir TAR_ARCHIVE_DIR]
+usage: superflore-gen-oe-recipes [-h] --ros-distro ROS_DISTRO --dry-run
+                                 [--pr-only] [--no-branch]
+                                 [--output-repository-path OUTPUT_REPOSITORY_PATH]
+                                 [--only ONLY [ONLY ...]]
+                                 [--pr-comment PR_COMMENT]
+                                 [--upstream-repo UPSTREAM_REPO]
+                                 [--upstream-branch UPSTREAM_BRANCH]
+                                 [--skip-keys SKIP_KEYS [SKIP_KEYS ...]]
+                                 [--tar-archive-dir TAR_ARCHIVE_DIR]
+
+Deploy ROS packages into OpenEmbedded Linux
 
 optional arguments:
   -h, --help            show this help message and exit

--- a/README.md
+++ b/README.md
@@ -37,11 +37,16 @@ Gentoo Usage:
 
 ### Generating Gentoo Ebuilds
 ```
-$ superflore-gen-ebuilds --help
+$ superflore-gen-ebuilds -h
 usage: Deploy ROS packages into Gentoo Linux [-h] [--ros-distro ROS_DISTRO]
-                                             [--all] [--dry-run] [--pr-only] [--no-branch]
+                                             [--all] [--dry-run] [--pr-only]
+                                             [--no-branch]
                                              [--output-repository-path OUTPUT_REPOSITORY_PATH]
                                              [--only ONLY [ONLY ...]]
+                                             [--pr-comment PR_COMMENT]
+                                             [--upstream-repo UPSTREAM_REPO]
+                                             [--upstream-branch UPSTREAM_BRANCH]
+                                             [--skip-keys SKIP_KEYS [SKIP_KEYS ...]]
 
 optional arguments:
   -h, --help            show this help message and exit
@@ -62,7 +67,7 @@ optional arguments:
                         https://github.com/<owner>/<repository>
   --upstream-branch UPSTREAM_BRANCH
                         branch of the upstream repository
-  --skip-keys SKIP_KEYS
+  --skip-keys SKIP_KEYS [SKIP_KEYS ...]
                         packages to skip during regeneration
 ```
 
@@ -140,12 +145,10 @@ OpenEmbedded Usage:
 should be followed to generate the OpenEmbedded recipes for `meta-ros`.
 
 ```
-$ superflore-gen-oe-recipes --help
-usage: Deploy ROS packages into OpenEmbedded Linux [-h]
-                                                   --ros-distro ROS_DISTRO
-                                                   --dry-run
-                                                   [--pr-only]
-                                                   [--no-branch]
+$ superflore-gen-oe-recipes -h
+usage: Deploy ROS packages into OpenEmbedded Linux [-h] --ros-distro
+                                                   ROS_DISTRO --dry-run
+                                                   [--pr-only] [--no-branch]
                                                    [--output-repository-path OUTPUT_REPOSITORY_PATH]
                                                    [--only ONLY [ONLY ...]]
                                                    [--pr-comment PR_COMMENT]

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ usage: superflore-gen-oe-recipes [-h] --ros-distro ROS_DISTRO --dry-run
                                  [--skip-keys SKIP_KEYS [SKIP_KEYS ...]]
                                  [--tar-archive-dir TAR_ARCHIVE_DIR]
 
-Deploy ROS packages into OpenEmbedded Linux
+Generate OpenEmbedded recipes for ROS packages
 
 optional arguments:
   -h, --help            show this help message and exit

--- a/superflore/generators/bitbake/run.py
+++ b/superflore/generators/bitbake/run.py
@@ -42,7 +42,7 @@ def main():
     os.environ["ROS_OS_OVERRIDE"] = "openembedded"
     overlay = None
     parser = get_parser(
-        'Deploy ROS packages into OpenEmbedded Linux',
+        'Generate OpenEmbedded recipes for ROS packages',
         exclude_all=True,
         require_rosdistro=True,
         require_dryrun=True)

--- a/superflore/parser.py
+++ b/superflore/parser.py
@@ -21,7 +21,7 @@ def get_parser(
     require_dryrun=False,
     require_rosdistro=False
 ):
-    parser = argparse.ArgumentParser(tool_tip)
+    parser = argparse.ArgumentParser(description=tool_tip)
     if is_generator:
         parser.add_argument(
             '--ros-distro',

--- a/superflore/test_integration/gentoo/main.py
+++ b/superflore/test_integration/gentoo/main.py
@@ -23,7 +23,7 @@ import yaml
 def main():
     tester = GentooBuilder()
     parser = argparse.ArgumentParser(
-        'Check if ROS packages are building for Gentoo Linux'
+        description='Check if ROS packages are building for Gentoo Linux'
     )
     parser.add_argument(
         '--ros-distro',

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -22,7 +22,7 @@ class TestParserSetup(unittest.TestCase):
     def test_get_parser(self):
         """Tests the get_parser function"""
         p = get_parser('test parser')
-        self.assertEqual(p.prog, 'test parser')
+        self.assertEqual(p.description, 'test parser')
         sys.argv = []
         ret = p.parse_args()
         self.assertIn('all', ret)


### PR DESCRIPTION
* Use keyword argument as
  https://docs.python.org/3/library/argparse.html#argparse.ArgumentParser
  recommends.
* Otherwise it ends on first line of usage like bellow.
  usage: Deploy ROS packages into OpenEmbedded Linux [-h]
                                                     [--ros-distro ROS_DISTRO]
                                                     --dry-run [--pr-only]
                                                     [--no-branch]
                                                     [--output-repository-path OUTPUT_REPOSITORY_PATH]
                                                     [--only ONLY [ONLY ...]]
                                                     [--pr-comment PR_COMMENT]
                                                     [--upstream-repo UPSTREAM_REPO]
                                                     [--upstream-branch UPSTREAM_BRANCH]
                                                     [--skip-keys SKIP_KEYS [SKIP_KEYS ...]]
                                                     [--tar-archive-dir TAR_ARCHIVE_DIR]
  optional arguments:
  ...

  instead of the expected:
  usage: superflore-gen-oe-recipes [-h] [--ros-distro ROS_DISTRO] --dry-run
                                   [--pr-only] [--no-branch]
                                   [--output-repository-path OUTPUT_REPOSITORY_PATH]
                                   [--only ONLY [ONLY ...]]
                                   [--pr-comment PR_COMMENT]
                                   [--upstream-repo UPSTREAM_REPO]
                                   [--upstream-branch UPSTREAM_BRANCH]
                                   [--skip-keys SKIP_KEYS [SKIP_KEYS ...]]
                                   [--tar-archive-dir TAR_ARCHIVE_DIR]

  Deploy ROS packages into OpenEmbedded Linux

  optional arguments:
  ...

Signed-off-by: Martin Jansa <martin.jansa@lge.com>