### PR TITLE
bitbake: generate new overrides syntax

### DIFF
--- a/superflore/generators/bitbake/yocto_recipe.py
+++ b/superflore/generators/bitbake/yocto_recipe.py
@@ -656,7 +656,7 @@ class yoctoRecipe(object):
                         'ROS_SUPERFLORE_GENERATED_BUILDTOOLS_%s' %
                         distro.upper(),
                         yoctoRecipe.generated_native_recipes) + '\n')
-                conf_file.write('ROS_SUPERFLORE_GENERATED_BUILDTOOLS_append ='
+                conf_file.write('ROS_SUPERFLORE_GENERATED_BUILDTOOLS:append ='
                                 ' " ${ROS_SUPERFLORE_GENERATED_BUILDTOOLS_%s}"'
                                 '\n\n' % distro.upper())
                 conf_file.write(yoctoRecipe.generate_multiline_variable(

--- a/superflore/generators/bitbake/yocto_recipe.py
+++ b/superflore/generators/bitbake/yocto_recipe.py
@@ -488,7 +488,7 @@ class yoctoRecipe(object):
         ret += ' staged should this package appear in another\'s DEPENDS.\n'
         ret += 'DEPENDS += "${ROS_EXPORT_DEPENDS} '
         ret += '${ROS_BUILDTOOL_EXPORT_DEPENDS}"\n\n'
-        ret += 'RDEPENDS_${PN} += "${ROS_EXEC_DEPENDS}"' + '\n\n'
+        ret += 'RDEPENDS:${PN} += "${ROS_EXEC_DEPENDS}"' + '\n\n'
         # SRC_URI
         ret += '# matches with: ' + self.src_uri + '\n'
         ret += 'ROS_BRANCH ?= "branch=' + self.get_repo_branch_name() + '"\n'


### PR DESCRIPTION
* generate new syntax for OE recipes to match:
  https://lists.openembedded.org/g/openembedded-architecture/message/1260
  https://lists.openembedded.org/g/openembedded-architecture/message/1279
  https://lists.openembedded.org/g/openembedded-architecture/message/1291

* this was already done with conversion script in meta-ros with:
  https://github.com/ros/meta-ros/pull/902
  but for new ROS Distribution releases we want to generate new
  syntax directly with superflore.

* it's not conditional based on OE release series, because all
  currently supported versions (dunfell, hardknott, honister)
  do support new syntax (when latest bitbake revision from
  corresponding branch is being used).

* fixes https://github.com/ros-infrastructure/superflore/issues/284

Signed-off-by: Martin Jansa <martin.jansa@lge.com>