### PR TITLE
Update of the manifest generation

### DIFF
--- a/superflore/generators/ebuild/ebuild.py
+++ b/superflore/generators/ebuild/ebuild.py
@@ -50,7 +50,7 @@ class Ebuild(object):
     This is where any necessary variables will be filled.
     """
     def __init__(self):
-        self.eapi = str(6)
+        self.eapi = str(8)
         self.description = ""
         self.homepage = "https://wiki.ros.org"
         self.src_uri = None
@@ -143,8 +143,8 @@ class Ebuild(object):
             # enable python 2.7 and python 3.5
             ret += self.get_python_compat(['2_7', '3_5', '3_6'])
         elif self.python_3 or (self.distro == 'noetic'):
-            # only use 3.5 - 3.9 for ROS 2 or noetic
-            ret += self.get_python_compat(['3_5', '3_6', '3_7', '3_8', '3_9'])
+            # only use 3.5 - 3.11 for ROS 2 or noetic
+            ret += self.get_python_compat(['3_5', '3_6', '3_7', '3_8', '3_9', '3_10', '3_11'])
         else:
             # fallback to python 2.7
             ret += self.get_python_compat(['2_7'])

--- a/superflore/generators/ebuild/overlay_instance.py
+++ b/superflore/generators/ebuild/overlay_instance.py
@@ -98,7 +98,7 @@ class RosOverlay(object):
                 for pkg in chunk:
                     pkg_dir = '/tmp/ros-overlay/ros-{0}/{1}'.format(distro, pkg)
                     dock.add_bash_command('cd {0}'.format(pkg_dir))
-                    dock.add_bash_command('repoman manifest')
+                    dock.add_bash_command('ebuild *.ebuild manifest')
                 try:
                     dock.run(show_cmd=True)
                     dock.clear_commands()


### PR DESCRIPTION
I updated the dockerfile ebuilds are built on and pushed it on docker hub. The current testing dockerfile is now under tomkimsour/ros_gentoo_base and the dockerfile can be found on ros-overlay repository once the pr I made gets accepted.

I also updated EAPI of the generated ebuild as well as the PYTHON_COMPAT. 