### PR TITLE
Add initial BuildStream backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Supported Platforms:
 --------------------
  * Gentoo
  * OpenEmbedded
+ * BuildStream
 
 Installation:
 =============
@@ -210,6 +211,68 @@ If you want to use an existing repo instead of cloning one, specify
 
 Note that the `--only` flag currently generates bogus files under `conf` and
 `files`.
+
+
+BuildStream Usage:
+===================
+
+### Generating BuildStream elements
+
+```
+$ superflore-gen-bst -h
+usage: superflore-gen-bst [-h] --ros-distro ROS_DISTRO --dry-run
+                          [--pr-only] [--no-branch]
+                          [--output-repository-path OUTPUT_REPOSITORY_PATH]
+                          [--only ONLY [ONLY ...]]
+                          [--pr-comment PR_COMMENT]
+                          [--upstream-repo UPSTREAM_REPO]
+                          [--upstream-branch UPSTREAM_BRANCH]
+                          [--skip-keys SKIP_KEYS [SKIP_KEYS ...]]
+                          [--tar-archive-dir TAR_ARCHIVE_DIR]
+                          [--generated-element-dir GENERATED_ELEMENT_DIR]
+
+Generate BuildStream elements for ROS packages
+
+options:
+  -h, --help            show this help message and exit
+  --ros-distro ROS_DISTRO
+                        regenerate packages for the specified distro
+  --dry-run             run without filing a PR to remote
+  --pr-only             ONLY file a PR to remote
+  --no-branch           Do not create a new branch automatically
+  --output-repository-path OUTPUT_REPOSITORY_PATH
+                        location of the Git repo
+  --only ONLY [ONLY ...]
+                        generate only the specified packages
+  --pr-comment PR_COMMENT
+                        comment to add to the PR
+  --upstream-repo UPSTREAM_REPO
+                        location of the upstream repository as in
+                        https://github.com/<owner>/<repository>
+  --upstream-branch UPSTREAM_BRANCH
+                        branch of the upstream repository
+  --skip-keys SKIP_KEYS [SKIP_KEYS ...]
+                        packages to skip during regeneration
+  --tar-archive-dir TAR_ARCHIVE_DIR
+                        location to store archived packages
+  --generated-element-dir GENERATED_ELEMENT_DIR
+                        directory for generated bst elements
+
+```
+
+Common Usage:
+--------------
+To update the BuildStream elements for a ROS distro, run the following:
+
+```
+$ git clone https://github.com/CodethinkLabs/ros2-bst
+$ git clone https://gitlab.com/freedesktop-sdk/freedesktop-sdk
+$ superflore-gen-bst --ros-distro ROS_DISTRO --output-repository-path ros2-bst --dry-run --only PACKAGE [PACKAGE ...]
+```
+
+This command will generate or update BuildStream elements in `ros2-bst` for
+the specified packages and their internal dependencies of the specified distro,
+using external dependencies defined in `ros2-bst` or `freedesktop-sdk`.
 
 
 F.A.Q.:

--- a/setup.py
+++ b/setup.py
@@ -86,6 +86,7 @@ setup(
         'console_scripts': [
             'superflore-gen-ebuilds = superflore.generators.ebuild:main',
             'superflore-gen-oe-recipes = superflore.generators.bitbake:main',
+            'superflore-gen-bst = superflore.generators.buildstream:main',
             'superflore-check-ebuilds = superflore.test_integration.gentoo:main',
         ]
     }

--- a/superflore/generators/bitbake/run.py
+++ b/superflore/generators/bitbake/run.py
@@ -15,7 +15,6 @@
 import os
 import sys
 
-from rosinstall_generator.distro import get_distro
 from rosinstall_generator.distro import get_package_names
 from superflore.CacheManager import CacheManager
 from superflore.generate_installers import generate_installers
@@ -30,6 +29,7 @@ from superflore.utils import err
 from superflore.utils import file_pr
 from superflore.utils import gen_delta_msg
 from superflore.utils import get_pr_text
+from superflore.utils import get_rosdistro
 from superflore.utils import get_utcnow_timestamp_str
 from superflore.utils import info
 from superflore.utils import load_pr
@@ -117,7 +117,7 @@ def main():
             srcrev_filename = None
         with CacheManager(srcrev_filename) as srcrev_cache:
             if args.only:
-                distro = get_distro(args.ros_distro)
+                distro = get_rosdistro(args.ros_distro, cached=not args.uncached_distro)
                 for pkg in args.only:
                     if pkg in skip_keys:
                         warn("Package '%s' is in skip-keys list, skipping..."
@@ -164,7 +164,7 @@ def main():
             overlay.clean_ros_recipe_dirs(args.ros_distro)
             for adistro in selected_targets:
                 yoctoRecipe.reset()
-                distro = get_distro(adistro)
+                distro = get_rosdistro(adistro, cached=not args.uncached_distro)
 
                 distro_installers, _, distro_changes =\
                     generate_installers(

--- a/superflore/generators/buildstream/__init__.py
+++ b/superflore/generators/buildstream/__init__.py
@@ -1,0 +1,3 @@
+from superflore.generators.buildstream.run import main
+if __name__ == '__main__':
+    main()

--- a/superflore/generators/buildstream/bst_element.py
+++ b/superflore/generators/buildstream/bst_element.py
@@ -1,0 +1,317 @@
+# Copyright (c) 2016 David Bensoussan, Synapticon GmbH
+# Copyright (c) 2017 Open Source Robotics Foundation, Inc.
+# Copyright (c) 2024 Codethink
+#
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to
+# deal  in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+# sell copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+#
+
+import os
+import textwrap
+import yaml
+
+from superflore.exceptions import NoPkgXml
+from superflore.exceptions import UnresolvedDependency
+from superflore.PackageMetadata import PackageMetadata
+from superflore.utils import err
+from superflore.utils import get_pkg_version
+from superflore.utils import info
+
+
+class BstElement(object):
+    def __init__(
+        self, component_name, pkg_name, pkg_xml, rosdistro, src_uri,
+        srcrev_cache, skip_keys, repo_dir, external_repos
+    ):
+        self.repo_dir = repo_dir
+        self.external_repos = external_repos
+        self.component = component_name
+        self.name = pkg_name
+        self.distro = rosdistro.name
+        self.version = get_pkg_version(rosdistro, pkg_name, is_oe=True)
+        self.src_uri = src_uri
+        self.pkg_xml = pkg_xml
+        self.author = None
+        if self.pkg_xml:
+            pkg_fields = PackageMetadata(pkg_xml)
+            maintainer_name = pkg_fields.upstream_name
+            maintainer_email = pkg_fields.upstream_email
+            author_name = pkg_fields.author_name
+            author_email = pkg_fields.author_email
+            self.maintainer = maintainer_name + ' <' + maintainer_email + '>'
+            if author_name or author_email:
+                self.author = author_name + \
+                    (' <' + author_email + '>' if author_email else '')
+            self.license = pkg_fields.upstream_license
+            self.description = pkg_fields.description
+            self.homepage = pkg_fields.homepage
+            pkg_build_type = pkg_fields.build_type
+            self.build_type = pkg_build_type
+        else:
+            self.description = ''
+            self.license = None
+            self.homepage = None
+            self.build_type = 'ament_cmake'
+            self.maintainer = "OSRF"
+        self.depends = set()
+        self.depends_external = set()
+        self.buildtool_depends = set()
+        self.buildtool_depends_external = set()
+        self.export_depends = set()
+        self.export_depends_external = set()
+        self.buildtool_export_depends = set()
+        self.buildtool_export_depends_external = set()
+        self.rdepends = set()
+        self.rdepends_external = set()
+        self.license_line = None
+        if self.src_uri not in srcrev_cache:
+            srcrev_cache[self.src_uri] = self.get_srcrev()
+        self.srcrev = srcrev_cache[self.src_uri]
+        self.skip_keys = skip_keys
+
+    def get_license_line(self):
+        self.license_line = ''
+        i = 0
+        if not self.pkg_xml:
+            raise NoPkgXml('No package xml file!')
+        for line in str(self.pkg_xml, 'utf-8').split('\n'):
+            i += 1
+            if 'license' in line:
+                self.license_line = str(i)
+                break
+
+    def get_repo_src_uri(self):
+        """
+        Parse out the git repository SRC_URI out of github archive, e.g.
+        github.com/ros2-gbp/ament_lint-release
+        from
+        https://github.com/ros2-gbp/ament_lint-release/archive/release/bouncy/ament_cmake_copyright/0.5.2-0.tar.gz
+        """
+        github_start = 'https://github.com/'
+        structure = self.src_uri.replace(github_start, '')
+        dirs = structure.split('/')
+        return "github:%s/%s" % (dirs[0], dirs[1])
+
+    def get_repo_branch_name(self):
+        """
+        Parse out the git branch name out of github archive SRC_URI, e.g.
+        release/bouncy/ament_cmake_copyright
+        from
+        https://github.com/ros2-gbp/ament_lint-release/archive/release/bouncy/ament_cmake_copyright/0.5.2-0.tar.gz
+        """
+        github_start = 'https://github.com/'
+        structure = self.src_uri.replace(github_start, '')
+        dirs = structure.split('/')
+        return '{0}/{1}/{2}'.format(
+            dirs[3], dirs[4], dirs[5]).replace('.tar.gz', '')
+
+    def get_repo_tag_name(self):
+        """
+        Parse out the git tag name out of github archive SRC_URI, e.g.
+        release/bouncy/ament_cmake_copyright/0.5.2-0
+        from
+        https://github.com/ros2-gbp/ament_lint-release/archive/release/bouncy/ament_cmake_copyright/0.5.2-0.tar.gz
+        """
+        github_start = 'https://github.com/'
+        structure = self.src_uri.replace(github_start, '')
+        dirs = structure.split('/')
+        return '{0}/{1}/{2}/{3}'.format(
+            dirs[3], dirs[4], dirs[5], dirs[6]).replace('.tar.gz', '')
+
+    def get_srcrev(self):
+        # e.g. git ls-remote https://github.com/ros2-gbp/ament_lint-release \
+        #                    release/bouncy/ament_cmake_copyright/0.5.2-0
+        # 48bf1aa1cb083a884fbc8520ced00523255aeaed \
+        #     refs/tags/release/bouncy/ament_cmake_copyright/0.5.2-0
+        # from https://github.com/ros2-gbp/ament_lint-release/archive/ \
+        #     release/bouncy/ament_cmake_copyright/0.5.2-0.tar.gz
+        from git.cmd import Git
+
+        g = Git()
+        for ref in g.execute(["git",
+                              "ls-remote",
+                              self.get_repo_src_uri().replace("github:", "https://github.com/"),
+                              "refs/tags/%s" % self.get_repo_tag_name()
+                              ]).split('\n'):
+            srcrev, tag = ref.split('\t')
+            if tag == "refs/tags/%s" % self.get_repo_tag_name():
+                return srcrev
+        err("Cannot map refs/tags/%s to srcrev in https://%s repository with "
+            "git ls-remote" % (self.get_repo_tag_name(),
+                               self.get_repo_src_uri()))
+        return "INVALID"
+
+    def add_build_depend(self, bdepend, pkg):
+        if bdepend not in self.skip_keys:
+            if pkg:
+                self.depends.add(pkg)
+            else:
+                self.depends_external.add(bdepend)
+
+    def add_buildtool_depend(self, btdepend, pkg):
+        if btdepend not in self.skip_keys:
+            if pkg:
+                self.buildtool_depends.add(pkg)
+            else:
+                self.buildtool_depends_external.add(btdepend)
+
+    def add_export_depend(self, edepend, pkg):
+        if edepend not in self.skip_keys:
+            if pkg:
+                self.export_depends.add(pkg)
+            else:
+                self.export_depends_external.add(edepend)
+
+    def add_buildtool_export_depend(self, btedepend, pkg):
+        if btedepend not in self.skip_keys:
+            if pkg:
+                self.buildtool_export_depends.add(pkg)
+            else:
+                self.buildtool_export_depends_external.add(btedepend)
+
+    def add_run_depend(self, rdepend, pkg):
+        if rdepend not in self.skip_keys:
+            if pkg:
+                self.rdepends.add(pkg)
+            else:
+                self.rdepends_external.add(rdepend)
+
+    @staticmethod
+    def convert_dep_name(dep):
+        return dep.lower().replace('_', '-')
+
+    @classmethod
+    def convert_to_bst_name(cls, dep):
+        return cls.convert_dep_name(dep) + ".bst"
+
+    def get_dependencies(self, internal_depends, external_depends):
+        dependencies = set()
+        system_dependencies = set()
+        for dep in internal_depends:
+            element = self.convert_dep_name(dep.repository_name) + "/" + self.convert_to_bst_name(dep.name)
+            dependencies.add("generated/" + element)
+            info('Internal dependency add: ' + element)
+        for dep in external_depends:
+            resolved = False
+            dep_bst = self.convert_to_bst_name(dep)
+            for external_repo_name, external_repo_path in self.external_repos.items():
+                if os.path.isfile(external_repo_path + '/' + dep_bst):
+                    resolved = True
+                    element = external_repo_name + dep_bst
+                    dependencies.add(element)
+                    system_dependencies.add(element)
+                    info('External dependency add: ' + element)
+                    break
+            if not resolved:
+                raise UnresolvedDependency("external dependency {} missing".format(dep))
+
+        return dependencies, system_dependencies
+
+    def get_element_text(self, distributor):
+        """
+        Generate the BuildStream element, given the distributor line
+        and the license text.
+        """
+        header = "# Generated by superflore -- DO NOT EDIT\n#\n"
+        header += "# Copyright " + distributor + "\n#\n"
+
+        if self.description:
+            self.description = self.description.replace('\n', ' ')
+            header += textwrap.fill('Description: ' + self.description,
+                                    width=80,
+                                    initial_indent='# ',
+                                    subsequent_indent='# ') + '\n'
+        header += '# Maintainer: ' + self.maintainer + '\n'
+        if self.author:
+            header += '# Author: ' + self.author + '\n'
+        if self.homepage:
+            header += '# Homepage: ' + self.homepage + '\n'
+        header += '# Source URI: ' + self.src_uri + '\n'
+        if self.license:
+            header += '# License: ' + " & ".join(self.license) + '\n'
+        header += '\n'
+
+        element = {}
+        base = "base.bst"
+        buildstack = [base]
+        if self.build_type in {"ament_cmake", "cmake"}:
+            element["kind"] = "cmake"
+            buildstack.append("freedesktop-sdk.bst:public-stacks/buildsystem-cmake.bst")
+        elif self.build_type == "ament_python":
+            element["kind"] = "pyproject"
+            buildstack.append("freedesktop-sdk.bst:public-stacks/buildsystem-python-setuptools.bst")
+
+        # depends
+        deps, sys_deps = self.get_dependencies(
+            self.depends, self.depends_external)
+        buildtool_native_deps, sys_deps = self.get_dependencies(
+            self.buildtool_depends,
+            self.buildtool_depends_external
+        )
+        native_deps = set(buildtool_native_deps)
+        export_deps, sys_deps = self.get_dependencies(
+            self.export_depends, self.export_depends_external)
+        buildtool_export_native_deps, sys_deps = self.get_dependencies(
+            self.buildtool_export_depends,
+            self.buildtool_export_depends_external
+        )
+        native_deps |= buildtool_export_native_deps
+        exec_deps, sys_deps = self.get_dependencies(
+            self.rdepends, self.rdepends_external)
+
+        element["build-depends"] = buildstack + sorted(deps | buildtool_native_deps)
+
+        element["runtime-depends"] = [base] + sorted(deps | export_deps | buildtool_export_native_deps | exec_deps)
+
+        variables = {}
+        if self.build_type == "ament_cmake":
+            variables["cmake-local"] = "-DBUILD_TESTING=OFF"
+        if variables:
+            element["variables"] = variables
+
+        sources = []
+        source = {}
+        source["kind"] = "git_repo"
+        source["url"] = self.get_repo_src_uri()
+        source["track"] = self.get_repo_branch_name()
+        source["ref"] = self.srcrev
+        sources.append(source)
+        element["sources"] = sources
+
+        includepath = "includes/" + \
+                      self.convert_dep_name(self.component) + "/" + \
+                      self.convert_dep_name(self.name) + ".inc"
+        fullincludepath = self.repo_dir + "/" + includepath
+        if os.path.isfile(fullincludepath):
+            with open(fullincludepath) as incfile:
+                include = yaml.safe_load(incfile)
+                for listkey in ["build-depends", "runtime-depends", "sources"]:
+                    if listkey in include:
+                        # Append generated list to list from include file
+                        element[listkey] = {"(<)": element[listkey]}
+                # BuildStream include directive
+                element["(@)"] = includepath
+
+        yamltext = yaml.dump(element, sort_keys=False)
+
+        # Improve formatting
+        for block in element.keys():
+            yamltext = yamltext.replace("\n" + block + ":", "\n\n" + block + ":")
+
+        return header + yamltext

--- a/superflore/generators/buildstream/bst_element.py
+++ b/superflore/generators/buildstream/bst_element.py
@@ -348,6 +348,13 @@ class BstElement(object):
                     if listkey in include and listkey in element:
                         # Append generated list to list from include file
                         element[listkey] = {"(<)": element[listkey]}
+
+                if "cmake-extra" in include.get("variables", {}):
+                    if "variables" not in element:
+                        element["variables"] = {}
+
+                    element["variables"]["cmake-local"] = "%{cmake-extra} " + element["variables"].get("cmake-local", "")
+
                 # BuildStream include directive
                 element["(@)"] = includepath
 

--- a/superflore/generators/buildstream/bst_element.py
+++ b/superflore/generators/buildstream/bst_element.py
@@ -40,6 +40,7 @@ class BstElement(object):
         srcrev_cache, skip_keys, repo_dir, external_repos,
         *,
         exclude_source,
+        evaluate_condition_context,
     ):
         self.repo_dir = repo_dir
         self.external_repos = external_repos
@@ -51,7 +52,7 @@ class BstElement(object):
         self.pkg_xml = pkg_xml
         self.author = None
         if self.pkg_xml:
-            pkg_fields = PackageMetadata(pkg_xml)
+            pkg_fields = PackageMetadata(pkg_xml, evaluate_condition_context)
             maintainer_name = pkg_fields.upstream_name
             maintainer_email = pkg_fields.upstream_email
             author_name = pkg_fields.author_name

--- a/superflore/generators/buildstream/gen_packages.py
+++ b/superflore/generators/buildstream/gen_packages.py
@@ -33,7 +33,8 @@ org = "Open Source Robotics Foundation"
 
 def regenerate_pkg(
     overlay, pkg, rosdistro, preserve_existing, srcrev_cache,
-    skip_keys, external_repos, generated_elements_dir = "elements/generated"
+    skip_keys, external_repos, generated_elements_dir = "elements/generated",
+    exclude_source=False,
 ):
     pkg_names = get_package_names(rosdistro)[0]
     if pkg not in pkg_names:
@@ -96,7 +97,8 @@ def regenerate_pkg(
         overlay.repo.remove_file(existing, True)
     try:
         current = bst_element(
-            rosdistro, pkg, srcrev_cache, skip_keys, repo_dir, external_repos
+            rosdistro, pkg, srcrev_cache, skip_keys, repo_dir, external_repos,
+            exclude_source=exclude_source,
         )
     except InvalidPackage as e:
         err('Invalid package: ' + str(e))
@@ -141,7 +143,9 @@ def regenerate_pkg(
 
 def _gen_element_for_package(
     rosdistro, pkg_name, pkg, repo, ros_pkg,
-    pkg_rosinstall, srcrev_cache, skip_keys, repo_dir, external_repos
+    pkg_rosinstall, srcrev_cache, skip_keys, repo_dir, external_repos,
+    *,
+    exclude_source,
 ):
     pkg_names = get_package_names(rosdistro)
     pkg_dep_walker = DependencyWalker(rosdistro)
@@ -170,6 +174,7 @@ def _gen_element_for_package(
         skip_keys,
         repo_dir,
         external_repos,
+        exclude_source=exclude_source,
     )
     # add build dependencies
     for bdep in pkg_build_deps:
@@ -196,7 +201,9 @@ def _gen_element_for_package(
 
 class bst_element(object):
     def __init__(
-        self, rosdistro, pkg_name, srcrev_cache, skip_keys, repo_dir, external_repos
+        self, rosdistro, pkg_name, srcrev_cache, skip_keys, repo_dir, external_repos,
+        *,
+        exclude_source,
     ):
         pkg = rosdistro.release_packages[pkg_name]
         repo = rosdistro.repositories[pkg.repository_name].release_repository
@@ -208,7 +215,8 @@ class bst_element(object):
 
         self.element = _gen_element_for_package(
             rosdistro, pkg_name, pkg, repo, ros_pkg, pkg_rosinstall,
-            srcrev_cache, skip_keys, repo_dir, external_repos
+            srcrev_cache, skip_keys, repo_dir, external_repos,
+            exclude_source=exclude_source,
         )
 
     def element_text(self):

--- a/superflore/generators/buildstream/gen_packages.py
+++ b/superflore/generators/buildstream/gen_packages.py
@@ -1,0 +1,215 @@
+# Copyright 2017 Open Source Robotics Foundation, Inc.
+# Copyright 2024 Codethink
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from catkin_pkg.package import InvalidPackage
+from rosdistro.dependency_walker import DependencyWalker
+from rosdistro.manifest_provider import get_release_tag
+from rosdistro.rosdistro import RosPackage
+from rosinstall_generator.distro import _generate_rosinstall
+from rosinstall_generator.distro import get_package_names
+from superflore.exceptions import NoPkgXml
+from superflore.generators.buildstream.bst_element import BstElement
+from superflore.utils import err
+from superflore.utils import get_pkg_version
+from superflore.utils import make_dir
+from superflore.utils import ok
+from superflore.utils import retry_on_exception
+from superflore.utils import warn
+
+org = "Open Source Robotics Foundation"
+
+
+def regenerate_pkg(
+    overlay, pkg, rosdistro, preserve_existing, srcrev_cache,
+    skip_keys, external_repos, generated_elements_dir = "elements/generated"
+):
+    pkg_names = get_package_names(rosdistro)[0]
+    if pkg not in pkg_names:
+        raise RuntimeError("Unknown package '%s' available packages"
+                           " in selected distro: %s" %
+                           (pkg, get_package_names(rosdistro)))
+    try:
+        version = get_pkg_version(rosdistro, pkg, is_oe=True)
+    except KeyError as ke:
+        raise ke
+    repo_dir = overlay.repo.repo_dir
+    component_name = BstElement.convert_dep_name(rosdistro.release_packages[pkg].repository_name)
+    element = BstElement.convert_to_bst_name(pkg)
+    # check for an existing element which was removed by clean_ros_element_dirs
+    prefix = '{0}/*/{1}'.format(
+        generated_elements_dir, element
+    )
+    existing = overlay.repo.git.status('--porcelain', '--', prefix)
+    if existing:
+        # The git status --porcelain output will look like this:
+        # D  elements/generated/variants/ros-base.bst
+        # we want just the path with filename
+        if len(existing.split('\n')) > 1:
+            warn('More than 1 element was output by "git status --porcelain '
+                 '{0}/*/{1}": "{2}"'
+                 .format(
+                     generated_elements_dir,
+                     element,
+                     existing))
+        if existing.split()[0] != 'D':
+            err('Unexpected output from "git status --porcelain '
+                 '{0}/*/{1}": "{2}"'
+                 .format(
+                     generated_elements_dir,
+                     element,
+                     existing))
+
+        existing = existing.split()[1]
+    else:
+        # If it isn't shown in git status, it could still exist as normal
+        # unchanged file when --only option is being used
+        import glob
+        existing = glob.glob('{0}/{1}'.format(repo_dir, prefix))
+        if existing:
+            if len(existing) > 1:
+                err('More than 1 element was output by "git status '
+                    '--porcelain '
+                     '{0}/*/{1}": "{2}"'
+                     .format(
+                         generated_elements_dir,
+                         element,
+                         existing))
+            existing = existing[0]
+
+    previous_version = None
+    if preserve_existing and existing:
+        ok("element for package '%s' up to date, skipping..." % pkg)
+        return None, [], None
+    elif existing:
+        overlay.repo.remove_file(existing, True)
+    try:
+        current = bst_element(
+            rosdistro, pkg, srcrev_cache, skip_keys, repo_dir, external_repos
+        )
+    except InvalidPackage as e:
+        err('Invalid package: ' + str(e))
+        return None, [], None
+    except Exception as e:
+        err('Failed generating element for {}! {}'.format(pkg, str(e)))
+        raise e ### debug
+        return None, [], None
+    try:
+        element_text = current.element_text()
+    except NoPkgXml as nopkg:
+        err("Could not fetch pkg! {}".format(str(nopkg)))
+        return None, [], None
+    except KeyError as ke:
+        err("Failed to parse data for package {}! {}".format(pkg, str(ke)))
+        return None, [], None
+    make_dir(
+        "{0}/{1}/{2}".format(
+            repo_dir,
+            generated_elements_dir,
+            component_name
+        )
+    )
+    success_msg = 'Successfully generated element for package'
+    ok('{0} \'{1}\'.'.format(success_msg, pkg))
+    element_file_name = '{0}/{1}/{2}/' \
+        '{3}'.format(
+            repo_dir,
+            generated_elements_dir,
+            component_name,
+            element
+        )
+    try:
+        with open('{0}'.format(element_file_name), "w") as element_file:
+            ok('Writing element {0}'.format(element_file_name))
+            element_file.write(element_text)
+    except Exception:
+        err("Failed to write element to disk!")
+        return None, [], None
+    return current, previous_version, element
+
+
+def _gen_element_for_package(
+    rosdistro, pkg_name, pkg, repo, ros_pkg,
+    pkg_rosinstall, srcrev_cache, skip_keys, repo_dir, external_repos
+):
+    pkg_names = get_package_names(rosdistro)
+    pkg_dep_walker = DependencyWalker(rosdistro)
+    pkg_buildtool_deps = pkg_dep_walker.get_depends(pkg_name, "buildtool")
+    pkg_build_deps = pkg_dep_walker.get_depends(pkg_name, "build")
+    pkg_build_export_deps = pkg_dep_walker.get_depends(
+        pkg_name, "build_export")
+    pkg_buildtool_export_deps = pkg_dep_walker.get_depends(
+        pkg_name, "buildtool_export")
+    pkg_exec_deps = pkg_dep_walker.get_depends(pkg_name, "exec")
+    src_uri = pkg_rosinstall[0]['tar']['uri']
+
+    # parse through package xml
+    err_msg = 'Failed to fetch metadata for package {}'.format(pkg_name)
+    pkg_xml = retry_on_exception(ros_pkg.get_package_xml, rosdistro.name,
+                                 retry_msg='Could not get package xml!',
+                                 error_msg=err_msg)
+
+    pkg_element = BstElement(
+        pkg.repository_name,
+        pkg_name,
+        pkg_xml,
+        rosdistro,
+        src_uri,
+        srcrev_cache,
+        skip_keys,
+        repo_dir,
+        external_repos,
+    )
+    # add build dependencies
+    for bdep in pkg_build_deps:
+        pkg_element.add_build_depend(bdep, rosdistro.release_packages.get(bdep))
+
+    # add build tool dependencies
+    for btdep in pkg_buildtool_deps:
+        pkg_element.add_buildtool_depend(btdep, rosdistro.release_packages.get(btdep))
+
+    # add export dependencies
+    for edep in pkg_build_export_deps:
+        pkg_element.add_export_depend(edep, rosdistro.release_packages.get(edep))
+
+    # add buildtool export dependencies
+    for btedep in pkg_buildtool_export_deps:
+        pkg_element.add_buildtool_export_depend(btedep, rosdistro.release_packages.get(btedep))
+
+    # add exec dependencies
+    for xdep in pkg_exec_deps:
+        pkg_element.add_run_depend(xdep, rosdistro.release_packages.get(xdep))
+
+    return pkg_element
+
+
+class bst_element(object):
+    def __init__(
+        self, rosdistro, pkg_name, srcrev_cache, skip_keys, repo_dir, external_repos
+    ):
+        pkg = rosdistro.release_packages[pkg_name]
+        repo = rosdistro.repositories[pkg.repository_name].release_repository
+        ros_pkg = RosPackage(pkg_name, repo)
+
+        pkg_rosinstall = _generate_rosinstall(
+            pkg_name, repo.url, get_release_tag(repo, pkg_name), True
+        )
+
+        self.element = _gen_element_for_package(
+            rosdistro, pkg_name, pkg, repo, ros_pkg, pkg_rosinstall,
+            srcrev_cache, skip_keys, repo_dir, external_repos
+        )
+
+    def element_text(self):
+        return self.element.get_element_text(org)

--- a/superflore/generators/buildstream/gen_packages.py
+++ b/superflore/generators/buildstream/gen_packages.py
@@ -35,6 +35,7 @@ def regenerate_pkg(
     overlay, pkg, rosdistro, preserve_existing, srcrev_cache,
     skip_keys, external_repos, generated_elements_dir = "elements/generated",
     exclude_source=False,
+    evaluate_condition_context=None,
 ):
     pkg_names = get_package_names(rosdistro)[0]
     if pkg not in pkg_names:
@@ -99,6 +100,7 @@ def regenerate_pkg(
         current = bst_element(
             rosdistro, pkg, srcrev_cache, skip_keys, repo_dir, external_repos,
             exclude_source=exclude_source,
+            evaluate_condition_context=evaluate_condition_context,
         )
     except InvalidPackage as e:
         err('Invalid package: ' + str(e))
@@ -146,9 +148,10 @@ def _gen_element_for_package(
     pkg_rosinstall, srcrev_cache, skip_keys, repo_dir, external_repos,
     *,
     exclude_source,
+    evaluate_condition_context,
 ):
     pkg_names = get_package_names(rosdistro)
-    pkg_dep_walker = DependencyWalker(rosdistro)
+    pkg_dep_walker = DependencyWalker(rosdistro, evaluate_condition_context)
     pkg_buildtool_deps = pkg_dep_walker.get_depends(pkg_name, "buildtool")
     pkg_build_deps = pkg_dep_walker.get_depends(pkg_name, "build")
     pkg_build_export_deps = pkg_dep_walker.get_depends(
@@ -175,6 +178,7 @@ def _gen_element_for_package(
         repo_dir,
         external_repos,
         exclude_source=exclude_source,
+        evaluate_condition_context=evaluate_condition_context,
     )
     # add build dependencies
     for bdep in pkg_build_deps:
@@ -204,6 +208,7 @@ class bst_element(object):
         self, rosdistro, pkg_name, srcrev_cache, skip_keys, repo_dir, external_repos,
         *,
         exclude_source,
+        evaluate_condition_context,
     ):
         pkg = rosdistro.release_packages[pkg_name]
         repo = rosdistro.repositories[pkg.repository_name].release_repository
@@ -217,6 +222,7 @@ class bst_element(object):
             rosdistro, pkg_name, pkg, repo, ros_pkg, pkg_rosinstall,
             srcrev_cache, skip_keys, repo_dir, external_repos,
             exclude_source=exclude_source,
+            evaluate_condition_context=evaluate_condition_context,
         )
 
     def element_text(self):

--- a/superflore/generators/buildstream/ros_bst_repo.py
+++ b/superflore/generators/buildstream/ros_bst_repo.py
@@ -1,0 +1,69 @@
+# Copyright 2017 Open Source Robotics Foundation, Inc.
+# Copyright 2024 Codethink
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from superflore.repo_instance import RepoInstance
+from superflore.utils import info
+
+
+class RosBstRepo(object):
+    def __init__(
+        self, dir, do_clone, branch, org, repo,
+        from_branch='', branch_name='', generated_elements_dir="elements/generated"
+    ):
+        self.repo = RepoInstance(
+            org, repo, dir, do_clone, from_branch=from_branch)
+        self.branch_name = branch
+        self.generated_elements_dir = generated_elements_dir
+        if branch:
+            info('Creating new branch {0}...'.format(self.branch_name))
+            self.repo.create_branch(self.branch_name)
+
+    def clean_ros_element_dirs(self, distro):
+        files = self.generated_elements_dir
+        info('Cleaning up:\n{0}'.format(files))
+        self.repo.git.rm('-rf', '--ignore-unmatch', files.split())
+
+    def commit_changes(self, distro, commit_msg):
+        info('Commit changes...')
+        if self.repo.git.status('--porcelain') == '':
+            info('Nothing changed; no commit done')
+        else:
+            if self.branch_name:
+                info('Committing to branch {0}...'.format(self.branch_name))
+            else:
+                info('Committing to current branch')
+            self.repo.git.commit(m=commit_msg)
+
+    def pull_request(self, message, distro=None, title=''):
+        self.repo.pull_request(message, title, branch=distro)
+
+    def get_file_revision_logs(self, *file_path):
+        return self.repo.git.log('--oneline', '--', *file_path)
+
+    def add_generated_files(self, distro):
+        info('Adding changes...')
+        self.repo.git.add(self.generated_elements_dir)
+
+    def get_change_summary(self, distro):
+        sep = '-' * 5
+        return '\n'.join([
+            sep,
+            self.repo.git.status('--porcelain'),
+            sep,
+            self.repo.git.diff(
+                'HEAD',
+                self.generated_elements_dir + '/'
+            ),
+        ]) + '\n'

--- a/superflore/generators/buildstream/run.py
+++ b/superflore/generators/buildstream/run.py
@@ -75,6 +75,12 @@ def main():
             default="elements/generated",
             help='directory for generated bst elements',
             type=str)
+    parser.add_argument(
+            '--exclude-sources-for',
+            default=[],
+            nargs='+',
+            help='do not generate sources for the specified packages',
+            type=str)
     args = parser.parse_args(sys.argv[1:])
     pr_comment = args.pr_comment
     skip_keys = set(args.skip_keys) if args.skip_keys else set()
@@ -146,6 +152,7 @@ def main():
             if args.only:
                 distro = get_distro(args.ros_distro)
                 packages = args.only
+                exclude_sources_for = args.exclude_sources_for
                 include_dependencies = True
                 if include_dependencies:
                     packages = set(packages) | \
@@ -165,6 +172,7 @@ def main():
                             srcrev_cache,
                             skip_keys=skip_keys,
                             external_repos=external_repos,
+                            exclude_source=pkg in exclude_sources_for
                         )
                     except KeyError:
                         err("No package to satisfy key '%s' available "

--- a/superflore/generators/buildstream/run.py
+++ b/superflore/generators/buildstream/run.py
@@ -1,0 +1,254 @@
+# Copyright 2017 Open Source Robotics Foundation, Inc.
+# Copyright 2024 Codethink
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import sys
+
+from rosdistro.dependency_walker import DependencyWalker
+from rosinstall_generator.distro import get_distro
+from rosinstall_generator.distro import get_package_names
+from superflore.CacheManager import CacheManager
+from superflore.generate_installers import generate_installers
+from superflore.generators.buildstream.gen_packages import regenerate_pkg
+from superflore.generators.buildstream.ros_bst_repo import RosBstRepo
+from superflore.generators.buildstream.bst_element import BstElement
+from superflore.parser import get_parser
+from superflore.repo_instance import RepoInstance
+from superflore.TempfileManager import TempfileManager
+from superflore.utils import clean_up
+from superflore.utils import err
+from superflore.utils import file_pr
+from superflore.utils import gen_delta_msg
+from superflore.utils import get_pr_text
+from superflore.utils import get_utcnow_timestamp_str
+from superflore.utils import info
+from superflore.utils import load_pr
+from superflore.utils import ok
+from superflore.utils import save_pr
+from superflore.utils import url_to_repo_org
+from superflore.utils import warn
+
+
+def get_recursive_dependencies(distro, package_names, excludes=None, limit_depth=None):
+    excludes = set(excludes or [])
+    dependencies = set([])
+    walker = DependencyWalker(distro)
+    for pkg_name in package_names:
+        try:
+            dependencies |= walker.get_recursive_depends(
+                pkg_name,
+                ['buildtool', 'buildtool_export', 'build', 'build_export', 'run'],
+                ros_packages_only=True,
+                ignore_pkgs=dependencies | excludes, limit_depth=limit_depth)
+        except AssertionError as e:
+            raise RuntimeError("Failed to fetch recursive dependencies of package '%s': %s" % (pkg_name, e))
+    dependencies -= set(package_names)
+    return dependencies
+
+
+def main():
+    overlay = None
+    parser = get_parser(
+        'Generate BuildStream elements for ROS packages',
+        exclude_all=True,
+        require_rosdistro=True,
+        require_dryrun=True)
+    parser.add_argument(
+        '--tar-archive-dir',
+        help='location to store archived packages',
+        type=str
+    )
+    parser.add_argument(
+            '--generated-element-dir',
+            default="elements/generated",
+            help='directory for generated bst elements',
+            type=str)
+    args = parser.parse_args(sys.argv[1:])
+    pr_comment = args.pr_comment
+    skip_keys = set(args.skip_keys) if args.skip_keys else set()
+    if args.pr_only:
+        if args.dry_run:
+            parser.error('Invalid args! cannot dry-run and file PR')
+        if not args.output_repository_path:
+            parser.error('Invalid args! no repository specified')
+        try:
+            prev_overlay = RepoInstance(args.output_repository_path, False)
+            msg, title = load_pr()
+            prev_overlay.pull_request(msg, title=title)
+            clean_up()
+            sys.exit(0)
+        except Exception as e:
+            err('Failed to file PR!')
+            err('reason: {0}'.format(e))
+            sys.exit(1)
+    warn('"{0}" distro detected...'.format(args.ros_distro))
+    selected_targets = [args.ros_distro]
+    preserve_existing = False
+    now = os.getenv(
+        'SUPERFLORE_GENERATION_DATETIME',
+        get_utcnow_timestamp_str())
+    # No default upstream repo yet
+    repo_org = None
+    repo_name = None
+    if args.upstream_repo:
+        repo_org, repo_name = url_to_repo_org(args.upstream_repo)
+    # open cached tar file if it exists
+    with TempfileManager(args.output_repository_path) as _repo:
+        if not args.output_repository_path:
+            # give our group write permissions to the temp dir
+            os.chmod(_repo, 17407)
+        # clone if args.output_repository_path is None
+        overlay = RosBstRepo(
+            _repo,
+            not args.output_repository_path,
+            branch=(('superflore/{}'.format(now)) if not args.no_branch
+                    else None),
+            org=repo_org,
+            repo=repo_name,
+            from_branch=args.upstream_branch,
+            generated_elements_dir=args.generated_element_dir
+        )
+        if not args.only:
+            pr_comment = pr_comment or (
+                'Elements generated by **superflore** for all packages in ROS '
+                'distribution {}.\n'.format(selected_targets[0])
+            )
+        else:
+            pr_comment = pr_comment or (
+                'Elements generated by **superflore** for package(s) {} in ROS '
+                'distribution {}.\n'.format(args.only, args.ros_distro)
+            )
+
+        external_repos = {}
+        external_repos["freedesktop-sdk.bst:components/"] = args.output_repository_path + "/../freedesktop-sdk/elements/components"
+        external_repos["external-deps/"] = args.output_repository_path + "/elements/external-deps"
+
+        # generate installers
+        total_installers = dict()
+        total_changes = dict()
+        if args.tar_archive_dir:
+            srcrev_filename = '%s/srcrev_cache.pickle' % args.tar_archive_dir
+        else:
+            srcrev_filename = None
+        with CacheManager(srcrev_filename) as srcrev_cache:
+            if args.only:
+                distro = get_distro(args.ros_distro)
+                packages = args.only
+                include_dependencies = True
+                if include_dependencies:
+                    packages = set(packages) | \
+                        get_recursive_dependencies(distro, packages, excludes=skip_keys)
+                for pkg in packages:
+                    if pkg in skip_keys:
+                        warn("Package '%s' is in skip-keys list, skipping..."
+                             % pkg)
+                        continue
+                    info("Regenerating package '%s'..." % pkg)
+                    try:
+                        regenerate_pkg(
+                            overlay,
+                            pkg,
+                            distro,
+                            preserve_existing,
+                            srcrev_cache,
+                            skip_keys=skip_keys,
+                            external_repos=external_repos,
+                        )
+                    except KeyError:
+                        err("No package to satisfy key '%s' available "
+                            "packages in selected distro: %s" %
+                            (pkg, get_package_names(distro)))
+                        sys.exit(1)
+                # Commit changes and file pull request
+                title =\
+                    '{{{0}}} Selected elements generated from '\
+                    'files/{0}/generated/cache.yaml '\
+                    'as of {1}\n'.format(
+                            args.ros_distro,
+                            now)
+                regen_dict = dict()
+                regen_dict[args.ros_distro] = args.only
+                delta = "Regenerated: '%s'\n" % args.only
+                overlay.add_generated_files(args.ros_distro)
+                commit_msg = '\n'.join([get_pr_text(
+                    title + '\n' + pr_comment.replace(
+                        '**superflore**', 'superflore'), markup=''), delta])
+                overlay.commit_changes(args.ros_distro, commit_msg)
+                if args.dry_run:
+                    save_pr(overlay, args.only, '', pr_comment, title=title)
+                    sys.exit(0)
+                file_pr(overlay, delta, '', pr_comment, distro=args.ros_distro,
+                        title=title)
+                ok('Successfully synchronized repositories!')
+                sys.exit(0)
+
+            overlay.clean_ros_element_dirs(args.ros_distro)
+            for adistro in selected_targets:
+                distro = get_distro(adistro)
+
+                distro_installers, _, distro_changes =\
+                    generate_installers(
+                        distro,
+                        overlay,
+                        regenerate_pkg,
+                        preserve_existing,
+                        srcrev_cache,
+                        skip_keys,
+                        external_repos,
+                        skip_keys=skip_keys,
+                        is_oe=True,
+                    )
+                total_changes[adistro] = distro_changes
+                total_installers[adistro] = distro_installers
+                BstElement.generate_newer_platform_components(
+                    _repo, args.ros_distro)
+                overlay.add_generated_files(args.ros_distro)
+
+        num_changes = 0
+        for distro_name in total_changes:
+            num_changes += len(total_changes[distro_name])
+
+        if num_changes == 0:
+            info('ROS distro is up to date.')
+            summary = overlay.get_change_summary(args.ros_distro)
+            if len(summary) == 0:
+                info('Exiting...')
+                clean_up()
+                sys.exit(0)
+            else:
+                info('But there are some changes in other regenerated files: '
+                     '%s' % summary)
+
+        # remove duplicates
+        delta = gen_delta_msg(total_changes, markup='')
+        # Commit changes and file pull request
+        title = '{{{0}}} Sync to files/{0}/generated/'\
+            'cache.yaml as of {1}\n'.format(
+                args.ros_distro,
+                now)
+        commit_msg = '\n'.join([get_pr_text(
+            title + '\n' + pr_comment.replace('**superflore**', 'superflore'),
+            markup=''), delta])
+        overlay.commit_changes(args.ros_distro, commit_msg)
+        delta = gen_delta_msg(total_changes)
+        if args.dry_run:
+            info('Running in dry mode, not filing PR')
+            save_pr(
+                overlay, delta, '', pr_comment, title=title,
+            )
+            sys.exit(0)
+        file_pr(overlay, delta, '', comment=pr_comment, title=title)
+        clean_up()
+        ok('Successfully synchronized repositories!')

--- a/superflore/generators/buildstream/run.py
+++ b/superflore/generators/buildstream/run.py
@@ -16,6 +16,7 @@
 import os
 import sys
 
+from rosdistro import get_package_condition_context
 from rosdistro.dependency_walker import DependencyWalker
 from rosinstall_generator.distro import get_package_names
 from superflore.CacheManager import CacheManager
@@ -31,6 +32,7 @@ from superflore.utils import err
 from superflore.utils import file_pr
 from superflore.utils import gen_delta_msg
 from superflore.utils import get_pr_text
+from superflore.utils import get_cached_index
 from superflore.utils import get_rosdistro
 from superflore.utils import get_utcnow_timestamp_str
 from superflore.utils import info
@@ -41,10 +43,10 @@ from superflore.utils import url_to_repo_org
 from superflore.utils import warn
 
 
-def get_recursive_dependencies(distro, package_names, excludes=None, limit_depth=None):
+def get_recursive_dependencies(distro, package_names, evaluate_condition_context, excludes=None, limit_depth=None):
     excludes = set(excludes or [])
     dependencies = set([])
-    walker = DependencyWalker(distro)
+    walker = DependencyWalker(distro, evaluate_condition_context)
     for pkg_name in package_names:
         try:
             dependencies |= walker.get_recursive_depends(
@@ -153,10 +155,11 @@ def main():
                 distro = get_rosdistro(args.ros_distro, cached=not args.uncached_distro)
                 packages = args.only
                 exclude_sources_for = args.exclude_sources_for
+                evaluate_condition_context = get_package_condition_context(get_cached_index(), args.ros_distro)
                 include_dependencies = True
                 if include_dependencies:
                     packages = set(packages) | \
-                        get_recursive_dependencies(distro, packages, excludes=skip_keys)
+                        get_recursive_dependencies(distro, packages, evaluate_condition_context, excludes=skip_keys)
                 for pkg in packages:
                     if pkg in skip_keys:
                         warn("Package '%s' is in skip-keys list, skipping..."
@@ -172,7 +175,8 @@ def main():
                             srcrev_cache,
                             skip_keys=skip_keys,
                             external_repos=external_repos,
-                            exclude_source=pkg in exclude_sources_for
+                            exclude_source=pkg in exclude_sources_for,
+                            evaluate_condition_context=evaluate_condition_context,
                         )
                     except KeyError:
                         err("No package to satisfy key '%s' available "

--- a/superflore/generators/buildstream/run.py
+++ b/superflore/generators/buildstream/run.py
@@ -17,7 +17,6 @@ import os
 import sys
 
 from rosdistro.dependency_walker import DependencyWalker
-from rosinstall_generator.distro import get_distro
 from rosinstall_generator.distro import get_package_names
 from superflore.CacheManager import CacheManager
 from superflore.generate_installers import generate_installers
@@ -32,6 +31,7 @@ from superflore.utils import err
 from superflore.utils import file_pr
 from superflore.utils import gen_delta_msg
 from superflore.utils import get_pr_text
+from superflore.utils import get_rosdistro
 from superflore.utils import get_utcnow_timestamp_str
 from superflore.utils import info
 from superflore.utils import load_pr
@@ -150,7 +150,7 @@ def main():
             srcrev_filename = None
         with CacheManager(srcrev_filename) as srcrev_cache:
             if args.only:
-                distro = get_distro(args.ros_distro)
+                distro = get_rosdistro(args.ros_distro, cached=not args.uncached_distro)
                 packages = args.only
                 exclude_sources_for = args.exclude_sources_for
                 include_dependencies = True
@@ -204,7 +204,7 @@ def main():
 
             overlay.clean_ros_element_dirs(args.ros_distro)
             for adistro in selected_targets:
-                distro = get_distro(adistro)
+                distro = get_rosdistro(adistro, cached=not args.uncached_distro)
 
                 distro_installers, _, distro_changes =\
                     generate_installers(

--- a/superflore/generators/ebuild/run.py
+++ b/superflore/generators/ebuild/run.py
@@ -15,7 +15,6 @@
 import os
 import sys
 
-from rosinstall_generator.distro import get_distro
 from superflore.exceptions import NoGitHubAuthToken
 from superflore.generate_installers import generate_installers
 from superflore.generators.ebuild.gen_packages import regenerate_pkg
@@ -29,6 +28,7 @@ from superflore.utils import file_pr
 from superflore.utils import gen_delta_msg
 from superflore.utils import gen_missing_deps_msg
 from superflore.utils import get_distros_by_status
+from superflore.utils import get_rosdistro
 from superflore.utils import info
 from superflore.utils import load_pr
 from superflore.utils import ok
@@ -129,7 +129,7 @@ def main():
                     ebuild, deps, version = regenerate_pkg(
                         overlay,
                         pkg,
-                        get_distro(args.ros_distro),
+                        get_rosdistro(args.ros_distro, cached=not args.uncached_distro),
                         preserve_existing
                     )
                     if not ebuild:
@@ -171,7 +171,7 @@ def main():
         for distro in selected_targets:
             distro_installers, distro_broken, distro_changes =\
                 generate_installers(
-                    get_distro(distro),
+                    get_rosdistro(distro, cached=not args.uncached_distro),
                     overlay=overlay,
                     gen_pkg_func=regenerate_pkg,
                     preserve_existing=preserve_existing,

--- a/superflore/parser.py
+++ b/superflore/parser.py
@@ -62,6 +62,10 @@ def get_parser(
             help='generate only the specified packages'
         )
         parser.add_argument(
+            '--uncached-distro',
+            help='Recreate the ros distribution rather than downloading a cached version',
+            action='store_true')
+        parser.add_argument(
             '--pr-comment',
             help='comment to add to the PR',
             type=str

--- a/superflore/utils.py
+++ b/superflore/utils.py
@@ -21,6 +21,7 @@ import string
 import sys
 import time
 
+import rosdistro
 from pkg_resources import DistributionNotFound, get_distribution
 from superflore.exceptions import UnknownPlatform
 from superflore.rosdep_support import get_cached_index, resolve_rosdep_key
@@ -708,6 +709,16 @@ def resolve_dep(pkg, os, distro=None):
 def get_distros():
     index = get_cached_index()
     return index.distributions
+
+def get_rosdistro(distro_name, *, cached):
+    index = get_cached_index()
+
+    if cached:
+        distro = rosdistro.get_cached_distribution(index, distro_name)
+    else:
+        distro = rosdistro.get_distribution(index, distro_name)
+
+    return distro
 
 
 def get_distros_by_status(status='active'):

--- a/tests/test_generate_installers.py
+++ b/tests/test_generate_installers.py
@@ -14,9 +14,9 @@
 
 import re
 
-from rosinstall_generator.distro import get_distro
 from superflore.exceptions import UnknownBuildType
 from superflore.generate_installers import generate_installers
+from superflore.utils install get_rosdistro
 import unittest
 
 
@@ -67,7 +67,7 @@ class TestGenerateInstallers(unittest.TestCase):
         acc = list()
         # attempt to generate the installers
         inst, broken, changes = generate_installers(
-            get_distro('lunar'), None, _gen_package, False, acc
+            get_rosdistro('lunar', cached=True), None, _gen_package, False, acc
         )
         # since we don't do anything, there should be no failures.
         self.assertEqual(broken,{})
@@ -78,7 +78,7 @@ class TestGenerateInstallers(unittest.TestCase):
         """Test for an unresolved dependency"""
         acc = list()
         inst, broken, changes = generate_installers(
-            get_distro('lunar'), None, _fail_if_p2os, False, acc
+            get_rosdistro('lunar', cached=True), None, _fail_if_p2os, False, acc
         )
         broken = [b for b in broken]
         total_list = inst + broken
@@ -93,7 +93,7 @@ class TestGenerateInstallers(unittest.TestCase):
         """Test how skipped packages are handled"""
         acc = list()
         inst, broken, changes = generate_installers(
-            get_distro('lunar'), None, _skip_if_p2os, True, acc
+            get_rosdistro('lunar', cached=True), None, _skip_if_p2os, True, acc
         )
         broken = [b for b in broken]
         total_list = inst + broken
@@ -108,7 +108,7 @@ class TestGenerateInstallers(unittest.TestCase):
         """Test exceptions"""
         acc = list()
         inst, broken, changes = generate_installers(
-            get_distro('lunar'), None, _raise_exceptions, True, acc
+            get_rosdistro('lunar', cached=True), None, _raise_exceptions, True, acc
         )
         # anything with a 'k', 'l', or a 'b' has been skipped
         for p in inst:
@@ -120,7 +120,7 @@ class TestGenerateInstallers(unittest.TestCase):
         changes_re = '(([a-zA-Z]|\_|[0-9])+)\ [0-9]\.[0-9]\.[0-9]("-r"[0-9])?'
         acc = list()
         inst, broken, changes = generate_installers(
-            get_distro('lunar'), None, _create_if_p2os, True, acc
+            get_rosdistro('lunar', cached=True), None, _create_if_p2os, True, acc
         )
         found = False
         for c in changes:


### PR DESCRIPTION
This adds a generator for [BuildStream](https://buildstream.build/) elements. https://github.com/CodethinkLabs/ros2-bst is a working BuildStream project for a subset of ROS Iron where all elements for ROS packages have been generated by this branch of superflore. It also includes manually written elements for some external dependencies and depends on [freedesktop-sdk](https://gitlab.com/freedesktop-sdk/freedesktop-sdk) for the base system and other external dependencies.

It currently cannot generate elements for all packages of a ROS distro as some packages require additional external dependencies. It's thus necessary to invoke superflore-gen-bst with the --only option to specify the target packages. Elements are also generated for internal dependencies of target packages.

The generated elements currently do not include test dependencies and test suites of packages are not run as part of the build process. This should be added as a future enhancement.