### PR TITLE
Add Docker container for development

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,38 @@
+# superflore-devel
+# Copyright (C) 2024 Wind River Systems, Inc.
+#
+# SPDX-License-Identifier: MIT
+#
+
+FROM osrf/ros2:devel
+
+ENV ROS_HOME="/home/ubuntu"
+ENV ROSDEP_SOURCE_PATH="/home/ubuntu/rosdep"
+ENV ROS_DISTRO="rolling"
+ENV ROSDISTRO_URL="https://raw.githubusercontent.com/ros/rosdistro/master/rosdep"
+ENV GIT_FULLNAME="Firstname Lastname"
+ENV GIT_EMAIL="firstname.lastname@example.com"
+
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y \
+        apt-utils \
+        curl \
+        locales \
+        python3 \
+        python3-pip \
+        python3.12-venv \
+        python3-virtualenv \
+        vim \
+        wget && \
+    apt-get clean && \
+    locale-gen en_US en_US.UTF-8 && \
+    update-locale LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8 && \
+    echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
+
+USER ubuntu
+WORKDIR /home/ubuntu
+
+RUN git config --global user.email "${GIT_EMAIL}" && \
+    git config --global user.name "${GIT_FULLNAME}"
+
+CMD ["/bin/bash"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ pyyaml
 pygithub
 catkin_pkg
 rospkg
+setuptools

--- a/setup_superflore.sh
+++ b/setup_superflore.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+set -x
+
+# export ROS_HOME=${HOME}
+if [ -z "$ROS_HOME" ]; then
+    echo "ROS_HOME is not set"
+    exit 1
+fi
+
+# export ROSDEP_SOURCE_PATH=${ROS_HOME}/rosdep
+if [ -z "$ROSDEP_SOURCE_PATH" ]; then
+    echo "ROSDEP_SOURCE_PATH is not set"
+    exit 1
+fi
+mkdir -p ${ROSDEP_SOURCE_PATH}
+
+PROJECT_DIR=$PWD
+
+python3 -m venv $HOME/superflore_venv
+source $HOME/superflore_venv/bin/activate
+python3 -m pip install .
+
+echo "Running rosdep init"
+rosdep init
+
+echo "Running rosdep update"
+rosdep update
+
+cd ${PROJECT_DIR}
+ROSDISTRO_GIT="https://github.com/ros/rosdistro"
+git clone ${ROSDISTRO_GIT} ${HOME}/rosdistro
+
+ROSDISTRO_URL="https://raw.githubusercontent.com/ros/rosdistro/master/rosdep"
+sed -i -e "s|${ROSDISTRO_URL}|file://${HOME}/rosdistro/rosdep|" ${ROSDEP_SOURCE_PATH}/20-default.list

--- a/superflore/generators/ebuild/gen_packages.py
+++ b/superflore/generators/ebuild/gen_packages.py
@@ -156,7 +156,8 @@ def _gen_metadata_for_package(
         warn("fetch metadata for package {}".format(pkg_name))
         return pkg_metadata_xml
     package_condition_context = _package_condition_context(distro.name)
-    pkg = PackageMetadata(pkg_xml, evaluate_condition_context=package_condition_context)
+    pkg = PackageMetadata(pkg_xml,
+                          evaluate_condition_context=package_condition_context)
     pkg_metadata_xml.upstream_email = pkg.upstream_email
     pkg_metadata_xml.upstream_name = pkg.upstream_name
     pkg_metadata_xml.longdescription = pkg.longdescription
@@ -174,7 +175,9 @@ def _gen_ebuild_for_package(
     pkg_ebuild.src_uri = pkg_rosinstall[0]['tar']['uri']
     pkg_names = get_package_names(distro)
     package_condition_context = _package_condition_context(distro.name)
-    pkg_dep_walker = DependencyWalker(distro, evaluate_condition_context=package_condition_context)
+    pkg_dep_walker = DependencyWalker(
+        distro,
+        evaluate_condition_context=package_condition_context)
 
     pkg_buildtool_deps = pkg_dep_walker.get_depends(pkg_name, "buildtool")
     pkg_build_deps = pkg_dep_walker.get_depends(pkg_name, "build")
@@ -209,7 +212,8 @@ def _gen_ebuild_for_package(
     except Exception:
         warn("fetch metadata for package {}".format(pkg_name))
         return pkg_ebuild
-    pkg = PackageMetadata(pkg_xml, evaluate_condition_context=package_condition_context)
+    pkg = PackageMetadata(pkg_xml,
+                          evaluate_condition_context=package_condition_context)
     pkg_ebuild.upstream_license = pkg.upstream_license
     pkg_ebuild.description = pkg.description
     pkg_ebuild.homepage = pkg.homepage

--- a/superflore/generators/ebuild/overlay_instance.py
+++ b/superflore/generators/ebuild/overlay_instance.py
@@ -82,7 +82,6 @@ class RosOverlay(object):
         dock.map_directory(self.repo.repo_dir, '/tmp/ros-overlay')
         for distro in regen_dict.keys():
             chunk_list = []
-            chunk_count = 0
             pkg_list = regen_dict[distro]
             while len(pkg_list) > 0:
                 current_chunk = list()
@@ -96,7 +95,8 @@ class RosOverlay(object):
             info("key_lists: '%s'" % chunk_list)
             for chunk in chunk_list:
                 for pkg in chunk:
-                    pkg_dir = '/tmp/ros-overlay/ros-{0}/{1}'.format(distro, pkg)
+                    pkg_dir = '/tmp/ros-overlay/ros-{0}/{1}'.format(distro,
+                                                                    pkg)
                     dock.add_bash_command('cd {0}'.format(pkg_dir))
                     dock.add_bash_command('repoman manifest')
                 try:


### PR DESCRIPTION
This Docker container is based on the osrf/ros2:devel container image.  It adds the additional dependencies required to develop superflore.

It may be used independently, but it is intended for use as a VSCode devcontainer for development of superflore.