### PR TITLE
Fix code style guide problems for PEP8 and Flake8

### DIFF
--- a/superflore/generators/ebuild/gen_packages.py
+++ b/superflore/generators/ebuild/gen_packages.py
@@ -156,7 +156,8 @@ def _gen_metadata_for_package(
         warn("fetch metadata for package {}".format(pkg_name))
         return pkg_metadata_xml
     package_condition_context = _package_condition_context(distro.name)
-    pkg = PackageMetadata(pkg_xml, evaluate_condition_context=package_condition_context)
+    pkg = PackageMetadata(pkg_xml,
+                          evaluate_condition_context=package_condition_context)
     pkg_metadata_xml.upstream_email = pkg.upstream_email
     pkg_metadata_xml.upstream_name = pkg.upstream_name
     pkg_metadata_xml.longdescription = pkg.longdescription
@@ -174,7 +175,9 @@ def _gen_ebuild_for_package(
     pkg_ebuild.src_uri = pkg_rosinstall[0]['tar']['uri']
     pkg_names = get_package_names(distro)
     package_condition_context = _package_condition_context(distro.name)
-    pkg_dep_walker = DependencyWalker(distro, evaluate_condition_context=package_condition_context)
+    pkg_dep_walker = DependencyWalker(
+        distro,
+        evaluate_condition_context=package_condition_context)
 
     pkg_buildtool_deps = pkg_dep_walker.get_depends(pkg_name, "buildtool")
     pkg_build_deps = pkg_dep_walker.get_depends(pkg_name, "build")
@@ -209,7 +212,8 @@ def _gen_ebuild_for_package(
     except Exception:
         warn("fetch metadata for package {}".format(pkg_name))
         return pkg_ebuild
-    pkg = PackageMetadata(pkg_xml, evaluate_condition_context=package_condition_context)
+    pkg = PackageMetadata(pkg_xml,
+                          evaluate_condition_context=package_condition_context)
     pkg_ebuild.upstream_license = pkg.upstream_license
     pkg_ebuild.description = pkg.description
     pkg_ebuild.homepage = pkg.homepage

--- a/superflore/generators/ebuild/overlay_instance.py
+++ b/superflore/generators/ebuild/overlay_instance.py
@@ -82,7 +82,6 @@ class RosOverlay(object):
         dock.map_directory(self.repo.repo_dir, '/tmp/ros-overlay')
         for distro in regen_dict.keys():
             chunk_list = []
-            chunk_count = 0
             pkg_list = regen_dict[distro]
             while len(pkg_list) > 0:
                 current_chunk = list()
@@ -96,7 +95,8 @@ class RosOverlay(object):
             info("key_lists: '%s'" % chunk_list)
             for chunk in chunk_list:
                 for pkg in chunk:
-                    pkg_dir = '/tmp/ros-overlay/ros-{0}/{1}'.format(distro, pkg)
+                    pkg_dir = '/tmp/ros-overlay/ros-{0}/{1}'.format(distro,
+                                                                    pkg)
                     dock.add_bash_command('cd {0}'.format(pkg_dir))
                     dock.add_bash_command('repoman manifest')
                 try:


### PR DESCRIPTION
The CI system picked up non-conformance issues with recent changes to the ebuild generator.

Fix lines that exceed 79 characters and remove an used chunk_count variable.