### PR TITLE
Replace pkg_resources usage with importlib.metadata.

### DIFF
--- a/superflore/__init__.py
+++ b/superflore/__init__.py
@@ -1,11 +1,6 @@
-try:
-    import pkg_resources
-    try:
-        __version__ = pkg_resources.require('superflore')[0].version
-    except pkg_resources.DistributionNotFound:
-        __version__ = 'unset'
-except (ImportError, OSError):
-    __version__ = 'unset'
+from superflore.version import VERSION
+
+__version__ = VERSION
 
 from .repo_instance import RepoInstance
 

--- a/superflore/utils.py
+++ b/superflore/utils.py
@@ -24,9 +24,9 @@ import time
 from typing import Dict
 import urllib.request
 
-from pkg_resources import DistributionNotFound, get_distribution
 from superflore.exceptions import UnknownPlatform
 from superflore.rosdep_support import get_cached_index, resolve_rosdep_key
+from superflore.version import VERSION
 from termcolor import colored
 
 
@@ -835,11 +835,7 @@ def retry_on_exception(callback, *args, max_retries=5, num_retry=0,
 
 
 def get_superflore_version():
-    try:
-        version = get_distribution("superflore").version
-    except DistributionNotFound:
-        version = 'Unknown'
-    return version
+    return VERSION
 
 
 def get_utcnow_timestamp_str():

--- a/superflore/version.py
+++ b/superflore/version.py
@@ -1,0 +1,10 @@
+VERSION = 'unset'
+
+try:
+    import importlib.metadata
+    try:
+        VERSION = importlib.metadata.metadata("superflore").get("version")
+    except importlib.metadata.PackageNotFoundError:
+        pass
+except (ImportError, OSError):
+    pass

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -17,8 +17,7 @@ import string
 import sys
 import time
 
-from pkg_resources import parse_version
-from superflore import __version__
+from superflore.version import VERSION
 from superflore.exceptions import UnknownPlatform
 from superflore.exceptions import UnresolvedDependency
 from superflore.TempfileManager import TempfileManager
@@ -261,6 +260,7 @@ class TestUtils(unittest.TestCase):
 
     def test_get_superflore_version(self):
         """Test get SuperFlore version"""
-        if __version__ != 'unset':
-            self.assertGreaterEqual(parse_version(get_superflore_version()),
-                                    parse_version('0.2.1'))
+        if VERSION != 'unset':
+            self.assertRegex(get_superflore_version(),
+                             r"^(\d{2}|[1-9]|0\.(\d{2}|[4-9]|3\.(\d{2}|[4-9]|3)))",
+                             "superflore version is lower than the last modification of this test.")


### PR DESCRIPTION
pkg_resources is only used to fetch and provide the current superflore version.

In fact, there's very little need to parse this version at all (which would also require adding the `packaging` module as a dependency. Instead of parsing the version for the test, I used a cursed regexp that will test the value is greater than the current release when present.

Resolves #314.