### PR TITLE
Resolve Flake8 conformance rules

### DIFF
--- a/superflore/rosdep_support.py
+++ b/superflore/rosdep_support.py
@@ -45,7 +45,6 @@ def get_cached_index():
 
 
 def get_view(os_name, os_version, ros_distro):
-    global view_cache
     key = os_name + os_version + ros_distro
     if key not in view_cache:
         value = get_catkin_view(ros_distro, os_name, os_version, False)


### PR DESCRIPTION
When running the Flake8 tool it detects the global keyword being used unnecessarily:

python -m flake8 superflore --import-order-style=google

superflore/rosdep_support.py:48:5: F824 `global view_cache` is unused:
  name is never assigned in scope