### PR TITLE
oelint: drop the space at the first line in a multiline assignment

### DIFF
--- a/superflore/generators/bitbake/yocto_recipe.py
+++ b/superflore/generators/bitbake/yocto_recipe.py
@@ -333,7 +333,7 @@ class yoctoRecipe(object):
         assignment = '{0} = "'.format(var)
         expression = '"\n'
         if container:
-            expression = ' \\' + cls.get_spacing_prefix()
+            expression = '\\' + cls.get_spacing_prefix()
             expression += cls.get_spacing_prefix().join(
                 [item + ' \\' for item in container]) + '\n"\n'
         return assignment + expression


### PR DESCRIPTION
This fixes this issue with the oelint-adv tool:
  info:oelint.vars.notneededspace:Space at the beginning of the var is not needed [branch:true]