### PR TITLE
oelint: avoid whitespaces around some variables

### DIFF
--- a/superflore/generators/bitbake/yocto_recipe.py
+++ b/superflore/generators/bitbake/yocto_recipe.py
@@ -392,11 +392,11 @@ class yoctoRecipe(object):
         else:
             ret += 'DESCRIPTION = "None"\n'
         # author
-        ret += 'AUTHOR = "' + self.maintainer + '"\n'
+        ret += 'AUTHOR = "' + self.maintainer.strip() + '"\n'
         if self.author:
-            ret += 'ROS_AUTHOR = "' + self.author + '"\n'
+            ret += 'ROS_AUTHOR = "' + self.author.strip() + '"\n'
         if self.homepage:
-            ret += 'HOMEPAGE = "' + self.homepage + '"\n'
+            ret += 'HOMEPAGE = "' + self.homepage.strip() + '"\n'
         # section
         ret += 'SECTION = "devel"\n'
         # license


### PR DESCRIPTION
e.g.
  kortex-description_0.2.2-2.bb:9:info:oelint.vars.notneededspace:Space at the beginning of the var is not needed [branch:true]