### PR TITLE
Remove the 'S = ' in the recipes.

### DIFF
--- a/superflore/generators/bitbake/yocto_recipe.py
+++ b/superflore/generators/bitbake/yocto_recipe.py
@@ -495,7 +495,7 @@ class yoctoRecipe(object):
         ret += 'SRC_URI = "git://' + self.get_repo_src_uri() + \
             ';${ROS_BRANCH};protocol=https"\n'
         ret += 'SRCREV = "' + self.srcrev + '"\n'
-        ret += 'S = "${WORKDIR}/git"\n\n'
+        ret += '\n'
         ret += 'ROS_BUILD_TYPE = "' + self.build_type + '"\n'
         # Inherits
         ret += '\n' + self.get_bottom_inherit_line()


### PR DESCRIPTION
This is not longer needed in Yocto recipes.
And must be removed for the Yocto release Whinlatter and master

This fixes this error:

  ERROR: Recipes that set S = "${WORKDIR}/git" or S = "${UNPACKDIR}/git" should remove that assignment, as S set by bitbake.conf in oe-core now works.

See:
  https://github.com/openembedded/openembedded-core/commit/46480a5e66747a673041fe4452a0ab14a1736d5e