### PR TITLE
Set correct pull request message for --dry-run case

### DIFF
--- a/superflore/generators/bitbake/run.py
+++ b/superflore/generators/bitbake/run.py
@@ -155,7 +155,7 @@ def main():
                     markup=''), delta])
                 overlay.commit_changes(args.ros_distro, commit_msg)
                 if args.dry_run:
-                    save_pr(overlay, args.only, '', pr_comment, title=title)
+                    save_pr(overlay, delta, '', pr_comment, title=title)
                     sys.exit(0)
                 file_pr(overlay, delta, '', pr_comment, distro=args.ros_distro,
                         title=title)

--- a/superflore/generators/ebuild/run.py
+++ b/superflore/generators/ebuild/run.py
@@ -150,15 +150,15 @@ def main():
             regen_dict[args.ros_distro] = to_commit
             overlay.regenerate_manifests(regen_dict)
             overlay.commit_changes(args.ros_distro)
+            delta = "Regenerated: '%s'\n" % args.only
             if args.dry_run:
                 save_pr(
                     overlay,
-                    args.only,
+                    delta,
                     missing_deps=gen_missing_deps_msg(missing_depends),
                     comment=pr_comment
                 )
                 sys.exit(0)
-            delta = "Regenerated: '%s'\n" % args.only
             file_pr(
                 overlay,
                 delta,

--- a/superflore/generators/nix/run.py
+++ b/superflore/generators/nix/run.py
@@ -143,10 +143,10 @@ def main():
                 regen_dict = dict()
                 regen_dict[args.ros_distro] = args.only
                 overlay.commit_changes(args.ros_distro)
-                if args.dry_run:
-                    save_pr(overlay, args.only, '', pr_comment)
-                    sys.exit(0)
                 delta = "Regenerated: '%s'\n" % args.only
+                if args.dry_run:
+                    save_pr(overlay, delta, '', pr_comment)
+                    sys.exit(0)
                 file_pr(overlay, delta, '', pr_comment, distro=args.ros_distro)
                 ok('Successfully synchronized repositories!')
                 sys.exit(0)


### PR DESCRIPTION
When --only is used, if --dry-run is used it calls save_pr(), otherwise file_pr() is called. This fix ensures that the same string value is passed to the delta parameter of both functions.

The call to save_pr was incorrectly passing the list args.only instead of the string delta which contains the contents of args.only

This caused a TypeError exception in get_pr_text when concatenating the list to a string.

  File ".../superflore/superflore/utils.py", line 59, in get_pr_text
    msg += '\n' + delta + '\n'
           ~~~~~^~~~~~~
  TypeError: can only concatenate str (not "list") to str