### PR TITLE
bitbake: Remove source directory variable in Whinlatter

### DIFF
--- a/superflore/generators/bitbake/yocto_recipe.py
+++ b/superflore/generators/bitbake/yocto_recipe.py
@@ -512,8 +512,9 @@ class yoctoRecipe(object):
         ret += 'SRCREV = "' + self.srcrev + '"\n'
         if (self.release):
             if Version(self._get_yocto_version(self.release)) < \
-               Version(yocto_releases['styhead']):
-                ret += 'S = "${WORKDIR}/git"\n\n'
+               Version(yocto_releases['whinlatter']):
+                ret += 'S = "${WORKDIR}/git"\n'
+        ret += '\n'
         ret += 'ROS_BUILD_TYPE = "' + self.build_type + '"\n'
         # Inherits
         ret += '\n' + self.get_bottom_inherit_line()


### PR DESCRIPTION
Styhead requires that S = "${WORKDIR}" be replaced with S = "${UNPACKDIR}", however S = "${WORKDIR}/git" is still supported.

Whinlatter no longer supports setting S = "${WORKDIR}/git".

See the Yocto Project release notes for details.