### PR TITLE
Allow running superflore with uncached rosdistro

### DIFF
--- a/superflore/generators/bitbake/run.py
+++ b/superflore/generators/bitbake/run.py
@@ -15,7 +15,6 @@
 import os
 import sys
 
-from rosinstall_generator.distro import get_distro
 from rosinstall_generator.distro import get_package_names
 from superflore.CacheManager import CacheManager
 from superflore.generate_installers import generate_installers
@@ -31,6 +30,7 @@ from superflore.utils import err
 from superflore.utils import file_pr
 from superflore.utils import gen_delta_msg
 from superflore.utils import get_pr_text
+from superflore.utils import get_rosdistro
 from superflore.utils import get_utcnow_timestamp_str
 from superflore.utils import info
 from superflore.utils import load_pr
@@ -125,7 +125,7 @@ def main():
             srcrev_filename = None
         with CacheManager(srcrev_filename) as srcrev_cache:
             if args.only:
-                distro = get_distro(args.ros_distro)
+                distro = get_rosdistro(args.ros_distro, cached=not args.uncached_distro)
                 for pkg in args.only:
                     if pkg in skip_keys:
                         warn("Package '%s' is in skip-keys list, skipping..."
@@ -174,7 +174,7 @@ def main():
             overlay.clean_ros_recipe_dirs(args.ros_distro)
             for adistro in selected_targets:
                 yoctoRecipe.reset()
-                distro = get_distro(adistro)
+                distro = get_rosdistro(adistro, cached=not args.uncached_distro)
 
                 distro_installers, _, distro_changes =\
                     generate_installers(

--- a/superflore/generators/ebuild/run.py
+++ b/superflore/generators/ebuild/run.py
@@ -15,7 +15,6 @@
 import os
 import sys
 
-from rosinstall_generator.distro import get_distro
 from superflore.exceptions import NoGitHubAuthToken
 from superflore.generate_installers import generate_installers
 from superflore.generators.ebuild.gen_packages import regenerate_pkg
@@ -29,6 +28,7 @@ from superflore.utils import file_pr
 from superflore.utils import gen_delta_msg
 from superflore.utils import gen_missing_deps_msg
 from superflore.utils import get_distros_by_status
+from superflore.utils import get_rosdistro
 from superflore.utils import info
 from superflore.utils import load_pr
 from superflore.utils import ok
@@ -129,7 +129,7 @@ def main():
                     ebuild, deps, version = regenerate_pkg(
                         overlay,
                         pkg,
-                        get_distro(args.ros_distro),
+                        get_rosdistro(args.ros_distro, cached=not args.uncached_distro),
                         preserve_existing
                     )
                     if not ebuild:
@@ -171,7 +171,7 @@ def main():
         for distro in selected_targets:
             distro_installers, distro_broken, distro_changes =\
                 generate_installers(
-                    get_distro(distro),
+                    get_rosdistro(distro, cached=not args.uncached_distro),
                     overlay=overlay,
                     gen_pkg_func=regenerate_pkg,
                     preserve_existing=preserve_existing,

--- a/superflore/parser.py
+++ b/superflore/parser.py
@@ -62,6 +62,10 @@ def get_parser(
             help='generate only the specified packages'
         )
         parser.add_argument(
+            '--uncached-distro',
+            help='Recreate the ros distribution rather than downloading a cached version',
+            action='store_true')
+        parser.add_argument(
             '--pr-comment',
             help='comment to add to the PR',
             type=str

--- a/superflore/utils.py
+++ b/superflore/utils.py
@@ -24,6 +24,7 @@ import time
 from typing import Dict
 import urllib.request
 
+import rosdistro
 from superflore.exceptions import UnknownPlatform
 from superflore.rosdep_support import get_cached_index, resolve_rosdep_key
 from superflore.version import VERSION
@@ -715,6 +716,16 @@ def resolve_dep(pkg, os, distro=None):
 def get_distros():
     index = get_cached_index()
     return index.distributions
+
+def get_rosdistro(distro_name, *, cached):
+    index = get_cached_index()
+
+    if cached:
+        distro = rosdistro.get_cached_distribution(index, distro_name)
+    else:
+        distro = rosdistro.get_distribution(index, distro_name)
+
+    return distro
 
 
 def get_distros_by_status(status='active'):

--- a/tests/test_generate_installers.py
+++ b/tests/test_generate_installers.py
@@ -14,9 +14,9 @@
 
 import re
 
-from rosinstall_generator.distro import get_distro
 from superflore.exceptions import UnknownBuildType
 from superflore.generate_installers import generate_installers
+from superflore.utils install get_rosdistro
 import unittest
 
 
@@ -67,7 +67,7 @@ class TestGenerateInstallers(unittest.TestCase):
         acc = list()
         # attempt to generate the installers
         inst, broken, changes = generate_installers(
-            get_distro('lunar'), None, _gen_package, False, acc
+            get_rosdistro('lunar', cached=True), None, _gen_package, False, acc
         )
         # since we don't do anything, there should be no failures.
         self.assertEqual(broken,{})
@@ -78,7 +78,7 @@ class TestGenerateInstallers(unittest.TestCase):
         """Test for an unresolved dependency"""
         acc = list()
         inst, broken, changes = generate_installers(
-            get_distro('lunar'), None, _fail_if_p2os, False, acc
+            get_rosdistro('lunar', cached=True), None, _fail_if_p2os, False, acc
         )
         broken = [b for b in broken]
         total_list = inst + broken
@@ -93,7 +93,7 @@ class TestGenerateInstallers(unittest.TestCase):
         """Test how skipped packages are handled"""
         acc = list()
         inst, broken, changes = generate_installers(
-            get_distro('lunar'), None, _skip_if_p2os, True, acc
+            get_rosdistro('lunar', cached=True), None, _skip_if_p2os, True, acc
         )
         broken = [b for b in broken]
         total_list = inst + broken
@@ -108,7 +108,7 @@ class TestGenerateInstallers(unittest.TestCase):
         """Test exceptions"""
         acc = list()
         inst, broken, changes = generate_installers(
-            get_distro('lunar'), None, _raise_exceptions, True, acc
+            get_rosdistro('lunar', cached=True), None, _raise_exceptions, True, acc
         )
         # anything with a 'k', 'l', or a 'b' has been skipped
         for p in inst:
@@ -120,7 +120,7 @@ class TestGenerateInstallers(unittest.TestCase):
         changes_re = '(([a-zA-Z]|\_|[0-9])+)\ [0-9]\.[0-9]\.[0-9]("-r"[0-9])?'
         acc = list()
         inst, broken, changes = generate_installers(
-            get_distro('lunar'), None, _create_if_p2os, True, acc
+            get_rosdistro('lunar', cached=True), None, _create_if_p2os, True, acc
         )
         found = False
         for c in changes:


### PR DESCRIPTION
This commits adds a new command line flag to force superflore (via the rosdistro python package) to regenerate the distribution information.

This is useful when running superflore with $ROSDISTRO_INDEX_URL set to get deterministic codegen. The rosdistro caches are updated to latest and not versioned, see https://github.com/ros/rosdistro/issues/47469.