### PR TITLE
Fixes for --pr-only support in the NixOS generator

### DIFF
--- a/superflore/generators/nix/run.py
+++ b/superflore/generators/nix/run.py
@@ -58,7 +58,11 @@ def main():
         if not args.output_repository_path:
             parser.error('Invalid args! no repository specified')
         try:
-            prev_overlay = NixRosOverlay(args.output_repository_path, False)
+            prev_overlay = NixRosOverlay(
+                args.output_repository_path,
+                False,
+                from_branch=args.upstream_branch,
+            )
             msg, title = load_pr()
             prev_overlay.pull_request(msg, title=title)
             clean_up()

--- a/superflore/generators/nix/run.py
+++ b/superflore/generators/nix/run.py
@@ -23,7 +23,6 @@ from superflore.generators.nix.gen_packages import regenerate_pkg, \
     regenerate_pkg_set
 from superflore.generators.nix.nix_ros_overlay import NixRosOverlay
 from superflore.parser import get_parser
-from superflore.repo_instance import RepoInstance
 from superflore.TempfileManager import TempfileManager
 from superflore.utils import clean_up, get_distros_by_status
 from superflore.utils import err
@@ -59,7 +58,7 @@ def main():
         if not args.output_repository_path:
             parser.error('Invalid args! no repository specified')
         try:
-            prev_overlay = RepoInstance(args.output_repository_path, False)
+            prev_overlay = NixRosOverlay(args.output_repository_path, False)
             msg, title = load_pr()
             prev_overlay.pull_request(msg, title=title)
             clean_up()


### PR DESCRIPTION
Hi @robwoolley and others!

I noticed just today that NixOS support has been merged (#309). Thanks for the effort.

For quite some time, we also use two other changes, which are needed for our use case and which I'm submitting here.

These were already merged to the [original fork with NixOS support](https://github.com/lopsided98/superflore/commits/nixos-support/) and are [used in our Nix ROS overlay](https://github.com/lopsided98/nix-ros-overlay/blob/master/pkgs/superflore/default.nix).

If this is merged here, we could switch to using upstream superflore version. I've just verified that it works and removes the `pkg_resources` warning (#315) :-)

If you need anything related to Nix support in the future, feel free to ping me.