### PR TITLE
utils: back off longer and correctly on retry_on_exception (#311)

### DIFF
--- a/superflore/utils.py
+++ b/superflore/utils.py
@@ -808,8 +808,9 @@ def download_file(url, filename):
         raise e
 
 
-def retry_on_exception(callback, *args, max_retries=5, num_retry=0,
-                       retry_msg='', error_msg='', sleep_secs=0.125):
+def retry_on_exception(callback, *args, max_retries=10, num_retry=0,
+                       retry_msg='', error_msg='', sleep_secs=1,
+                       max_sleep_secs=60):
     try:
         return callback(*args)
     except Exception as e:
@@ -823,15 +824,18 @@ def retry_on_exception(callback, *args, max_retries=5, num_retry=0,
                 warn('{0} {1} {2}/{3}...'.format(str(e), retry_msg,
                      num_retry, max_retries))
             time.sleep(sleep_secs)
-            if num_retry <= 6:
-                sleep_secs *= 2
-            else:
-                sleep_secs = 0.125
+            # Keep backing off at increasing intervals, capped at
+            # max_sleep_secs, rather than resetting to a short interval.
+            # This matters most when many CI jobs are retrying against
+            # GitHub concurrently: a short/reset interval keeps them all
+            # hammering the rate limit instead of letting it clear.
+            sleep_secs = min(sleep_secs * 2, max_sleep_secs)
         elif num_retry == 0:
             warn('{0}'.format(str(e)))
         return retry_on_exception(callback, *args, max_retries=max_retries,
                                   num_retry=num_retry+1, retry_msg=retry_msg,
-                                  error_msg=error_msg, sleep_secs=sleep_secs)
+                                  error_msg=error_msg, sleep_secs=sleep_secs,
+                                  max_sleep_secs=max_sleep_secs)
 
 
 def get_superflore_version():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -228,7 +228,8 @@ class TestUtils(unittest.TestCase):
         self.assertEqual(retry_on_exception(callback_basic, 1), 'Success')
         # Checks failure case
         with self.assertRaises(Exception):
-            retry_on_exception(callback_basic, 2)
+            retry_on_exception(callback_basic, 2, max_retries=1,
+                                sleep_secs=0.01)
         # Checks callback can receive multiple params
         self.assertEqual(retry_on_exception(callback_params, 3, 4), 'Success')
         # Checks it doesn't retry when max_retries is zero; runs just once
@@ -244,19 +245,24 @@ class TestUtils(unittest.TestCase):
         # Checks it gets retried 2 times before succeeding at the 3rd
         callback_retries.limit = 0
         self.assertEqual(retry_on_exception(
-            callback_retries, 3, max_retries=3), 3)
+            callback_retries, 3, max_retries=3, sleep_secs=0.01), 3)
         # Checks it gets retried 3 times before giving up fully
         callback_retries.limit = -1
         with self.assertRaises(Exception):
-            retry_on_exception(callback_retries, 4, max_retries=3)
+            retry_on_exception(callback_retries, 4, max_retries=3,
+                                sleep_secs=0.01)
         self.assertEqual(callback_retries.limit, 3)
-        # Check that when retrying 9 times it'll sleep at least 16 seconds
-        # 0 + 0.125 + 0.25 + 0.5 + 1 + 2 + 4 + 8 + 0.125 = 16 seconds
+        # Check that the backoff interval doubles on each retry, capped at
+        # max_sleep_secs, and does NOT reset to a short interval once it
+        # hits the cap (it used to, which defeated the point of backing
+        # off under sustained rate limiting)
+        # 0 + 0.01 + 0.02 + 0.04 + 0.08 + 0.08 = 0.23 seconds
         time_before = time.time()
         with self.assertRaises(Exception):
-            retry_on_exception(callback_basic, 2, max_retries=9)
+            retry_on_exception(callback_basic, 2, max_retries=6,
+                                sleep_secs=0.01, max_sleep_secs=0.08)
         elapsed_time = time.time()-time_before
-        self.assertAlmostEqual(elapsed_time, 16, places=0)
+        self.assertAlmostEqual(elapsed_time, 0.23, delta=0.1)
 
     def test_get_superflore_version(self):
         """Test get SuperFlore version"""


### PR DESCRIPTION
Fixes ros-infrastructure/superflore#311. Under concurrent CI load (multiple distro/platform combinations running at once), GitHub rate limits package.xml fetches with HTTP 429. retry_on_exception's default backoff totaled under 2 seconds (5 retries, starting at 0.125s) -- nowhere near enough for the rate limit to clear -- so fetches were giving up and packages silently failed to generate.

Two changes:
- Raise the default retry budget so the backoff can actually ride out a real rate-limit window (10 retries, starting at 1s, doubling up to a 60s cap).
- Fix the cap logic itself: it previously reset the interval back down to 0.125s after 6 retries instead of staying capped high, which meant retries sped back up right when they should have kept backing off the most under sustained rate limiting.